### PR TITLE
chore(license): update to use spdx id

### DIFF
--- a/src/chsrc.c
+++ b/src/chsrc.c
@@ -9,7 +9,7 @@
  *
  *   Change Source —— 命令行换源工具
  *
- *   该软件为自由软件，采用 GPLv3 许可证，请查阅 LICENSE.txt 文件
+ *   SPDX-License-Identifier: GPL-3.0-or-later
  * ------------------------------------------------------------*/
 
 #define Chsrc_Version "v0.1.5-2024/06/05"


### PR DESCRIPTION
👋 I got a homebrew-core PR to include the project, but I am bit confused with the license, so this is the update, also update to use spdx id, https://spdx.org/licenses/ (GPL-3.0 is deprecated). Let me know what you think.

relates to https://github.com/Homebrew/homebrew-core/pull/173951