### PR TITLE
fix problem in chsrc_get_cpuarch() and chsrc_prepend_to_file()

### DIFF
--- a/include/chsrc.h
+++ b/include/chsrc.h
@@ -4,7 +4,7 @@
  * File          : chsrc.h
  * Authors       : Aoran Zeng <ccmywish@qq.com>
  *               | Heng Guo   <2085471348@qq.com>
- * Contributors  : Null Nil   <null@nil.com>
+ * Contributors  : Peng Gao   <gn3po4g@outlook.com>
  *               |
  * Created on    : <2023-08-29>
  * Last modified : <2024-07-03>

--- a/include/chsrc.h
+++ b/include/chsrc.h
@@ -680,7 +680,7 @@ chsrc_prepend_to_file (const char *str, const char *file)
     }
   else
     {
-      cmd = xy_strjoin (4, "sed -i '1i ", str, "'", file);
+      cmd = xy_strjoin (4, "sed -i '1i ", str, "' ", file);
     }
   chsrc_run (cmd, RunOpt_Default);
 }
@@ -750,7 +750,7 @@ chsrc_get_cpuarch ()
   exist = chsrc_check_program ("uname");
   if (exist)
     {
-      ret = xy_run ("uname -p", 0, NULL);
+      ret = xy_run ("uname -m", 0, NULL);
       return ret;
     }
   else


### PR DESCRIPTION
在函数`chsrc_get_cpuarch()`中，查看cpu命令应该是`uname -m`?
https://github.com/RubyMetric/chsrc/blob/aa7ec3fb82583aa88a407859d4784a0aa98eec1c/include/chsrc.h#L753

`chsrc_prepend_to_file()`函数似乎忘记了添加空格导致sed命令缺少文件参数，
应为`xy_strjoin (4, "sed -i '1i ", str, "' ", file);`
https://github.com/RubyMetric/chsrc/blob/aa7ec3fb82583aa88a407859d4784a0aa98eec1c/include/chsrc.h#L683