### PR TITLE
AUR自动构建支持

### DIFF
--- a/.github/workflows/pkg-aur-bin.yml
+++ b/.github/workflows/pkg-aur-bin.yml
@@ -1,0 +1,42 @@
+# This workflow will publish the `chsrc` package to the AUR
+#   when there is a new `released` event.
+name: Publish AUR Package (chsrc)
+on:
+  release:
+    types: [ released ]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Get the release tag
+      id: get_tag
+      run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+    - name: Validate version tag
+      run: |
+        if [[ ! ${{ steps.get_tag.outputs.tag }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "Abnormal version tag: ${{ steps.get_tag.outputs.tag }}"
+          echo "valid=false" >> $GITHUB_ENV
+        else
+          echo "version=${{ steps.get_tag.outputs.tag:1 }}" >> $GITHUB_ENV
+          echo "valid=true" >> $GITHUB_ENV
+        fi
+    - name: Fetch PKGBUILD
+      run: |
+        wget https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD\?h\=chsrc -O ./PKGBUILD
+    - name: Update PKGBUILD
+      run: |
+        sed -i "s/pkgver=.*/pkgver=${{ env.version }}/" PKGBUILD
+    - name: Publish to AUR
+      uses: KSXGitHub/github-actions-deploy-aur@v3.0.1
+      with:
+        pkgname: chsrc
+        pkgbuild: ./PKGBUILD
+        updpkgsums: true
+        test: true # Check that PKGBUILD could be built, and update pkgver
+        commit_username: ${{ secrets.AUR_USERNAME }}
+        commit_email: ${{ secrets.AUR_EMAIL }}
+        # ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        ssh_private_key: placeholder
+        commit_message: github-action-auto-publish

--- a/.github/workflows/pkg-aur-bin.yml
+++ b/.github/workflows/pkg-aur-bin.yml
@@ -17,10 +17,11 @@ jobs:
       run: |
         if [[ ! ${{ steps.get_tag.outputs.tag }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
           echo "Abnormal version tag: ${{ steps.get_tag.outputs.tag }}"
-          echo "valid=false" >> $GITHUB_ENV
+          echo "Exiting..."
+          exit 0
         else
-          echo "version=${{ steps.get_tag.outputs.tag:1 }}" >> $GITHUB_ENV
-          echo "valid=true" >> $GITHUB_ENV
+          tag=$(echo ${{ steps.get_tag.outputs.tag }} | sed 's/^v//')
+          echo "version=$tag" >> $GITHUB_ENV
         fi
     - name: Fetch PKGBUILD
       run: |

--- a/.github/workflows/pkg-aur-bin.yml
+++ b/.github/workflows/pkg-aur-bin.yml
@@ -1,5 +1,6 @@
 # This workflow will publish the `chsrc` package to the AUR
 #   when there is a new `released` event.
+# Note: only normal version tags like `v1.2.3` will be published.
 name: Publish AUR Package (chsrc)
 on:
   release:
@@ -38,6 +39,5 @@ jobs:
         test: true # Check that PKGBUILD could be built, and update pkgver
         commit_username: ${{ secrets.AUR_USERNAME }}
         commit_email: ${{ secrets.AUR_EMAIL }}
-        # ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
-        ssh_private_key: placeholder
+        ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
         commit_message: github-action-auto-publish

--- a/.github/workflows/pkg-aur-bin.yml
+++ b/.github/workflows/pkg-aur-bin.yml
@@ -27,9 +27,11 @@ jobs:
           echo "valid=1" >> $GITHUB_ENV
         fi
     - name: Fetch PKGBUILD
+      if: env.valid == '1'
       run: |
         wget https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD\?h\=chsrc -O ./PKGBUILD
     - name: Update PKGBUILD
+      if: env.valid == '1'
       run: |
         sed -i "s/pkgver=.*/pkgver=$version/" PKGBUILD
     - name: Publish to AUR

--- a/.github/workflows/pkg-aur-bin.yml
+++ b/.github/workflows/pkg-aur-bin.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Validate version tag
       run: |
         if [[ ! $tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-          echo "Abnormal version tag: $tag""
+          echo "Abnormal version tag: $tag"
           echo "valid=0" >> $GITHUB_ENV
         else
           version=$(echo $tag | sed 's/^v//')
@@ -27,11 +27,9 @@ jobs:
           echo "valid=1" >> $GITHUB_ENV
         fi
     - name: Fetch PKGBUILD
-      if: env.valid == '1'
       run: |
         wget https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD\?h\=chsrc -O ./PKGBUILD
     - name: Update PKGBUILD
-      if: env.valid == '1'
       run: |
         sed -i "s/pkgver=.*/pkgver=$version/" PKGBUILD
     - name: Publish to AUR

--- a/.github/workflows/pkg-aur-bin.yml
+++ b/.github/workflows/pkg-aur-bin.yml
@@ -13,7 +13,6 @@ jobs:
     steps:
     - name: Get the release tag
       id: get_tag
-      # run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
       run: |
         echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
     - name: Validate version tag

--- a/.github/workflows/pkg-aur-bin.yml
+++ b/.github/workflows/pkg-aur-bin.yml
@@ -13,24 +13,27 @@ jobs:
     steps:
     - name: Get the release tag
       id: get_tag
-      run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+      # run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+      run: |
+        echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
     - name: Validate version tag
       run: |
-        if [[ ! ${{ steps.get_tag.outputs.tag }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-          echo "Abnormal version tag: ${{ steps.get_tag.outputs.tag }}"
-          echo "Exiting..."
-          exit 0
+        if [[ ! $tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "Abnormal version tag: $tag""
+          echo "valid=0" >> $GITHUB_ENV
         else
-          tag=$(echo ${{ steps.get_tag.outputs.tag }} | sed 's/^v//')
-          echo "version=$tag" >> $GITHUB_ENV
+          version=$(echo $tag | sed 's/^v//')
+          echo "version=$version" >> $GITHUB_ENV
+          echo "valid=1" >> $GITHUB_ENV
         fi
     - name: Fetch PKGBUILD
       run: |
         wget https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD\?h\=chsrc -O ./PKGBUILD
     - name: Update PKGBUILD
       run: |
-        sed -i "s/pkgver=.*/pkgver=${{ env.version }}/" PKGBUILD
+        sed -i "s/pkgver=.*/pkgver=$version/" PKGBUILD
     - name: Publish to AUR
+      if: env.valid == '1'
       uses: KSXGitHub/github-actions-deploy-aur@v3.0.1
       with:
         pkgname: chsrc
@@ -39,5 +42,6 @@ jobs:
         test: true # Check that PKGBUILD could be built, and update pkgver
         commit_username: ${{ secrets.AUR_USERNAME }}
         commit_email: ${{ secrets.AUR_EMAIL }}
-        ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        # ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        ssh_private_key: placeholder
         commit_message: github-action-auto-publish

--- a/.github/workflows/pkg-aur-bin.yml
+++ b/.github/workflows/pkg-aur-bin.yml
@@ -42,6 +42,5 @@ jobs:
         test: true # Check that PKGBUILD could be built, and update pkgver
         commit_username: ${{ secrets.AUR_USERNAME }}
         commit_email: ${{ secrets.AUR_EMAIL }}
-        # ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
-        ssh_private_key: placeholder
+        ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
         commit_message: github-action-auto-publish

--- a/.github/workflows/pkg-aur-git.yml
+++ b/.github/workflows/pkg-aur-git.yml
@@ -1,0 +1,26 @@
+# This workflow will publish the `chsrc-git` package to the AUR
+#   when the main branch is updated.
+name: Publish AUR Package (chsrc-git)
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "main" ] # chsrc-git syncs with main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Fetch PKGBUILD
+      run: |
+        wget https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD\?h\=chsrc-git -O ./PKGBUILD
+    - name: Publish to AUR
+      uses: KSXGitHub/github-actions-deploy-aur@v3.0.1
+      with:
+        pkgname: chsrc-git
+        pkgbuild: ./PKGBUILD
+        test: true # Check that PKGBUILD could be built, and update pkgver
+        commit_username: ${{ secrets.AUR_USERNAME }}
+        commit_email: ${{ secrets.AUR_EMAIL }}
+        ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        commit_message: github-action-auto-publish


### PR DESCRIPTION
添加了`chsrc`和`chsrc-git`两个版本的AUR自动构建workflow，但还有一些问题需要协商解决：

### 触发条件设定

目前我设定的触发条件如下：
- chsrc: 正式发布时触发（`released`事件），并且忽略所有非常规版本号的发布（仅接受如v1.2.3）
- chsrc-git: main分支推送时触发

上述设计的合理性需要由作者确认

### AUR认证密钥

发布AUR包需要提供包维护者的私钥，使用`secrets`环境变量传入，[参见](https://github.com/Jerry-Terrasse/chsrc-aur-support/blob/79a0b619f00e843a349db56a965ce1d3ad17b920/.github/workflows/pkg-aur-bin.yml#L44)

我目前想到两个方案：
1. 如果作者乐意进行一些操作，可以在AUR注册帐号，我将你添加为co-maintainer，即可进行自动推送;
2. 也可以由我维护一个仓库专用于自动推送，并在主仓库中配置webhook来触发;

或许也有更好的方案？
