### PR TITLE
调整AUR包名

### DIFF
--- a/.github/workflows/pkg-aur-git.yml
+++ b/.github/workflows/pkg-aur-git.yml
@@ -23,4 +23,4 @@ jobs:
         commit_username: ${{ secrets.AUR_USERNAME }}
         commit_email: ${{ secrets.AUR_EMAIL }}
         ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
-        commit_message: github-action-auto-publish
+        commit_message: "github-action-auto-publish\n${{ github.sha }}"

--- a/.github/workflows/pkg-aur-rel.yml
+++ b/.github/workflows/pkg-aur-rel.yml
@@ -41,8 +41,8 @@ jobs:
         test: true # Check that PKGBUILD could be built, and update pkgver
         commit_username: ${{ secrets.AUR_USERNAME }}
         commit_email: ${{ secrets.AUR_EMAIL }}
-        ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY__ }}
-        commit_message: github-action-auto-publish
+        ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        commit_message: "github-action-auto-publish v${{ env.version }}"
     - name: Fetch PKGBUILD
       run: |
         wget https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD\?h\=chsrc -O ./PKGBUILD
@@ -59,5 +59,5 @@ jobs:
         test: true # Check that PKGBUILD could be built, and update pkgver
         commit_username: ${{ secrets.AUR_USERNAME }}
         commit_email: ${{ secrets.AUR_EMAIL }}
-        ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY__ }}
-        commit_message: github-action-auto-publish
+        ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        commit_message: "github-action-auto-publish v${{ env.version }}"

--- a/.github/workflows/pkg-aur-rel.yml
+++ b/.github/workflows/pkg-aur-rel.yml
@@ -1,7 +1,7 @@
-# This workflow will publish the `chsrc` package to the AUR
+# This workflow will publish the `chsrc` and the `chsrc-bin` packages to the AUR
 #   when there is a new `released` event.
 # Note: only normal version tags like `v1.2.3` will be published.
-name: Publish AUR Package (chsrc)
+name: Publish AUR Package (chsrc, chsrc-bin)
 on:
   release:
     types: [ released ]
@@ -27,11 +27,29 @@ jobs:
         fi
     - name: Fetch PKGBUILD
       run: |
+        wget https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD\?h\=chsrc-bin -O ./PKGBUILD_bin
+    - name: Update PKGBUILD
+      run: |
+        sed -i "s/pkgver=.*/pkgver=$version/" PKGBUILD_bin
+    - name: Publish chsrc-bin to AUR
+      if: env.valid == '1'
+      uses: KSXGitHub/github-actions-deploy-aur@v3.0.1
+      with:
+        pkgname: chsrc-bin
+        pkgbuild: ./PKGBUILD_bin
+        updpkgsums: true
+        test: true # Check that PKGBUILD could be built, and update pkgver
+        commit_username: ${{ secrets.AUR_USERNAME }}
+        commit_email: ${{ secrets.AUR_EMAIL }}
+        ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY__ }}
+        commit_message: github-action-auto-publish
+    - name: Fetch PKGBUILD
+      run: |
         wget https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD\?h\=chsrc -O ./PKGBUILD
     - name: Update PKGBUILD
       run: |
         sed -i "s/pkgver=.*/pkgver=$version/" PKGBUILD
-    - name: Publish to AUR
+    - name: Publish chsrc to AUR
       if: env.valid == '1'
       uses: KSXGitHub/github-actions-deploy-aur@v3.0.1
       with:
@@ -41,5 +59,5 @@ jobs:
         test: true # Check that PKGBUILD could be built, and update pkgver
         commit_username: ${{ secrets.AUR_USERNAME }}
         commit_email: ${{ secrets.AUR_EMAIL }}
-        ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY__ }}
         commit_message: github-action-auto-publish


### PR DESCRIPTION
受到[社区的提醒](https://aur.archlinux.org/packages/chsrc#comment-989472)，查阅[ArchWiki](https://wiki.archlinux.org/title/AUR_submission_guidelines#Rules_of_submission)发现之前的做法有误，通过二进制打包的版本应当以`-bin`作为后缀。

目前我的打算是：
1. 将原本的`chsrc`包迁移到`chsrc-bin`包名下，作为二进制分发的版本
2. 遵循惯例，将`chsrc`包改为从Standard Release的源码编译安装
3. `chsrc-git`包保持不变，即从main分支进行编译安装

注：顺便更新了一下commit message，使其包含更多信息。