### PR TITLE
    Fix Fedora

### DIFF
--- a/src/chsrc-main.c
+++ b/src/chsrc-main.c
@@ -12,6 +12,7 @@
  *                 |   Mr. Will    <mr.will.com@outlook.com>
  *                 |   Terrasse    <terrasse@qq.com>
  *                 |   Lontten     <lontten@163.com>
+ *                 | happy game    <happygame1024@gmail.com>
  *                 |
  * Created On      : <2023-08-28>
  * Last Modified   : <2024-10-04>

--- a/src/recipe/os/YUM/Fedora-Linux.c
+++ b/src/recipe/os/YUM/Fedora-Linux.c
@@ -4,7 +4,7 @@
  * File Authors  :  Heng Guo  <2085471348@qq.com>
  * Contributors  : Aoran Zeng <ccmywish@qq.com>
  * Created On    : <2023-09-26>
- * Last Modified : <2024-10-09>
+ * Last Modified : <2024-10-09> <happygame1024@gmail.com>
  *
  * 名称为 Fedora Linux
  * ------------------------------------------------------------*/

--- a/src/recipe/os/YUM/Fedora-Linux.c
+++ b/src/recipe/os/YUM/Fedora-Linux.c
@@ -4,13 +4,13 @@
  * File Authors  :  Heng Guo  <2085471348@qq.com>
  * Contributors  : Aoran Zeng <ccmywish@qq.com>
  * Created On    : <2023-09-26>
- * Last Modified : <2024-09-14>
+ * Last Modified : <2024-10-09>
  *
  * 名称为 Fedora Linux
  * ------------------------------------------------------------*/
 
 /**
- * @update 2024-09-14
+ * @update 2024-10-09
  */
 static SourceInfo
 os_fedora_sources[] = {
@@ -28,7 +28,9 @@ def_sources_n(os_fedora);
 
 
 /**
- * @note fedora 29 及以下版本暂不支持
+ * @note fedora 38 及以下版本暂不支持
+ * 参考:
+ * 1. https://mirrors.ustc.edu.cn/help/fedora.html
  */
 void
 os_fedora_setsrc (char *option)
@@ -37,27 +39,25 @@ os_fedora_setsrc (char *option)
 
   chsrc_yield_source_and_confirm (os_fedora);
 
-  chsrc_note2 ("Fedora 29 及以下版本暂不支持");
+  chsrc_note2 ("Fedora 38 及以下版本暂不支持");
 
   chsrc_backup ("/etc/yum.repos.d/fedora.repo");
   chsrc_backup ("/etc/yum.repos.d/fedora-updates.repo");
 
-  char* cmd = xy_strjoin (9, "sed -e 's|^metalink=|#metalink=|g' ",
+  char* cmd = xy_strjoin (7, "sed ",
          "-e 's|^#baseurl=http://download.example/pub/fedora/linux/|baseurl=",
          source.url,
          "|g' ",
          "-i.bak ",
          "/etc/yum.repos.d/fedora.repo ",
-         "/etc/yum.repos.d/fedora-modular.repo ",
-         "/etc/yum.repos.d/fedora-updates.repo ",
-         "/etc/yum.repos.d/fedora-updates-modular.repo");
+         "/etc/yum.repos.d/fedora-updates.repo");
 
   chsrc_run (cmd, RunOpt_Default);
 
   chsrc_log2 ("已替换文件 /etc/yum.repos.d/fedora.repo");
-  chsrc_log2 ("已新增文件 /etc/yum.repos.d/fedora-modular.repo");
   chsrc_log2 ("已替换文件 /etc/yum.repos.d/fedora-updates.repo");
-  chsrc_log2 ("已新增文件 /etc/yum.repos.d/fedora-updates-modular.repo");
+  
+  chsrc_note2 ("chsrc 已为您更换baseurl, 但fedora默认会优先使用metalink来匹配最快的源, 如您在获取metadata时速度较慢可自行将其注释");
 
   chsrc_run ("dnf makecache", RunOpt_No_Last_New_Line);
   chsrc_conclude (&source, SetsrcType_Auto);


### PR DESCRIPTION
- 不再支持fedora 38及以下版本
- 默认使用metalink匹配最快源, 提示用户可自行注释