### PR TITLE
Rewrite pwsh script

### DIFF
--- a/tool/install.ps1
+++ b/tool/install.ps1
@@ -3,7 +3,7 @@
 # File Authors  : Aoran Zeng <ccmywish@qq.com>
 #               |   ChatGPT  <https://chatgpt.com/>
 # Created On    : <2024-10-26>
-# Last Modified : <2024-10-26>
+# Last Modified : <2024-10-27>
 #
 #
 #         chsrc installer for Windows
@@ -26,6 +26,7 @@ $global:arch = ""
 $global:version = ""                         
 $global:url = ""                             
 $global:flag = 0
+
 # 安装说明的多行字符串
 $installInstructions = @"
 Hey friend
@@ -155,9 +156,6 @@ function DownLoad {
     # 执行下载
     try {
         Invoke-WebRequest -OutFile ($global:path + $fileName) -Uri $global:url -ErrorAction Stop
-
-        # curl.exe -Lo $global:path $global:url
-
         Write-Host "Downloading $binary_name ($global:arch architecture, $platform platform, version $global:version) to $global:path"
         Write-Host "🎉 Installation completed, path: $global:path"
     } catch {

--- a/tool/install.ps1
+++ b/tool/install.ps1
@@ -48,7 +48,7 @@ https://github.com/RubyMetric/chsrc
 function Help {
     Write-Host 
 @"
-chsrc-installer: Install chsrc on any Unix-like OS
+chsrc-installer: Install chsrc on ${platform}.
 
 Usage: install.sh [options]
 Options:

--- a/tool/install.ps1
+++ b/tool/install.ps1
@@ -166,23 +166,6 @@ function DownLoad {
     }
 }
 
-# function DownLoad {
-
-#     try {
-#         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-#         Invoke-WebRequest -Uri $url -Method Head | `
-#             Where-Object -FilterScript { $_.StatusCode -ne 200 }  # 检查状态码是否为 200
-#     }
-#     catch {
-#         Write-Host "Unable to download ${binary_name}. Please check your internet connection."
-#         exit 1  # 下载失败，输出错误信息并退出
-    
-#     }
-#     Invoke-WebRequest -OutFile $path $url
-#     Write-Host "Downloading $binary_name ($arch architecture, $platform platform, version $version) to $path"
-#     Write-Host "🎉 Installation completed, path: $path_to_executable"
-# }
-
 # 定义清理函数
 function Cleanup {
     if ($flag -eq 1) {
@@ -194,7 +177,7 @@ function Cleanup {
 }
 
 # 注册退出事件
-Register-EngineEvent PowerShell.Exiting -Action { Cleanup }
+$null = Register-EngineEvent PowerShell.Exiting -Action { Cleanup }
 
 # 下载chsrc
 

--- a/tool/install.ps1
+++ b/tool/install.ps1
@@ -9,31 +9,196 @@
 #         chsrc installer for Windows
 #
 # ---------------------------------------------------------------
+# 定义参数
+param(
+    [switch]
+    $h,
+    $d = "${Home}\.chsrc\bin", 
+    $v = "pre"
+)
+$fileName = "\chsrc.exe"
+$default_path = "${Home}\.chsrc\bin"  
+$binary_name = "chsrc"
+$platform = "Windows"
 
-# [Environment]::Is64BitProcess # True
+$global:path = ""                            
+$global:arch = ""                            
+$global:version = ""                         
+$global:url = ""                             
+$global:flag = 0
+# 安装说明的多行字符串
+$installInstructions = @"
+Hey friend
 
-$osarch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+This installer is only available for ${platform}.
+If you're looking for installation instructions for your operating system,
+please visit the following link:
+"@
 
-$dlarch = ""
+# 检查当前操作系统是否为 macOS 或 Linux
+if ($IsMacOS -or $IsLinux) {
+    Write-Host @"
+$installInstructions
 
-switch ($osarch) {
-
-  "Arm64" {
-    $dlarch = "arm64"
-    Write-Error "Unsupported platform Arm64";
-  }
-
-  "Arm"   {
-    $dlarch = "arm"
-    Write-Error "Unsupported platform Arm";
-  }
-
-  'X64' { $dlarch = "x64" }
-  'X86' { $dlarch = "x86" }
+https://github.com/RubyMetric/chsrc
+"@
+    exit  # 退出脚本
 }
 
-$url = "https://gitee.com/RubyMetric/chsrc/releases/download/pre/chsrc-${dlarch}-windows.exe"
+function Help {
+    Write-Host 
+@"
+chsrc-installer: Install chsrc on any Unix-like OS
 
-Write-Output "[INFO] URL: $url"
-curl.exe -L $url -o chsrc.exe
-Write-Output "🎉 Installation completed, path: ./chsrc.exe"
+Usage: install.sh [options]
+Options:
+    -h              Print this help information.
+    -d <directory>  Specify installation directory, default is $default_path.
+    -v <version>    Specify chsrc version.
+
+"@
+}
+
+# 执行帮助函数
+if ($h) {
+    Help
+    exit
+}
+
+function Get_Path {
+    # 检查目录是否存在
+    if (-not (Test-Path -Path $d -PathType Container)) {
+        # 如果目录不存在，执行下面的代码块
+        try {
+            New-Item -Path $d -ItemType Directory -Force | Out-Null
+            Write-Host "Directory created: $d"
+            $global:flag = 1
+        } catch {
+            # 捕获异常并输出错误信息
+            Write-Host "Failed to create directory: $_"
+            exit 1
+        }
+    }
+    $global:path=$d
+    # 输出最终路径
+    Write-Output "The path is set to: $global:path"
+}
+
+function Get_Version {
+    # 定义有效的版本
+    $pattern = '^(0\.1\.[4-9]|pre)$'
+
+    # 检查版本号是否符合
+    if ($v -notmatch $pattern) {
+        # 输出错误信息并结束程序
+        Write-Host "Error: Invalid version '$v'."
+        Write-Host "Please provide a valid version (0.1.4 - 0.1.9 or 'pre')."
+        exit 1
+    }
+
+    # 设置版本号
+    $global:version=$v
+    Write-Host "Version: $global:version"
+}
+
+function Get_Url {
+    # 获取 CPU 型号
+    $cpuArchitecture = Get-WmiObject Win32_Processor `
+                        | Select-Object -First 1 -ExpandProperty Architecture
+
+    # 将 CPU 型号转换为 x64 或 x86
+    switch ($cpuArchitecture) {
+        0 { $global:arch = 'x86' }
+        9 { 
+            # 如果是 64 位操作系统，选择 x64 安装包，否则选择 x86
+            if ([Environment]::Is64BitOperatingSystem) {
+                $global:arch = "x64"
+            }
+            else {
+                $global:arch = "x86"
+            }
+        }
+        default {
+            Write-Host "Error: Unsupported architecture '$cpuArchitecture'."
+            Write-Host "Only x86 or x64 architectures are supported."
+            exit 1
+        }
+    }
+    Write-Host "CPU Architecture: $global:arch"
+
+    # Set URL
+    $global:url =  "https://gitee.com/RubyMetric/chsrc/releases/download/" + `
+                "${global:version}/chsrc-${global:arch}-windows.exe"
+
+    Write-Host "DownLoad URL: $global:url."
+}
+
+function DownLoad {
+    try {
+        # 设置安全协议为 TLS 1.2
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        
+        # 检查 URL 是否可访问
+        $response = Invoke-WebRequest -Uri $global:url -Method Head -ErrorAction Stop
+        
+        # 检查状态码是否为 200
+        if ($response.StatusCode -ne 200) {
+            Write-Host "Error: Unable to access $global:url. Status code: $($response.StatusCode)"
+            exit 1  # 状态码不为 200，退出
+        }
+    }
+    catch {
+        Write-Host "Unable to download ${binary_name}. Please check your internet connection."
+        exit 1  # 下载失败，输出错误信息并退出
+    }
+
+    # 执行下载
+    try {
+        Invoke-WebRequest -OutFile ($global:path + $fileName) -Uri $global:url -ErrorAction Stop
+
+        # curl.exe -Lo $global:path $global:url
+
+        Write-Host "Downloading $binary_name ($global:arch architecture, $platform platform, version $global:version) to $global:path"
+        Write-Host "🎉 Installation completed, path: $global:path"
+    } catch {
+        Write-Host "Error: Unable to download $binary_name. Error: $_"
+        exit 1  # 下载失败，输出错误信息并退出
+    }
+}
+
+# function DownLoad {
+
+#     try {
+#         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+#         Invoke-WebRequest -Uri $url -Method Head | `
+#             Where-Object -FilterScript { $_.StatusCode -ne 200 }  # 检查状态码是否为 200
+#     }
+#     catch {
+#         Write-Host "Unable to download ${binary_name}. Please check your internet connection."
+#         exit 1  # 下载失败，输出错误信息并退出
+    
+#     }
+#     Invoke-WebRequest -OutFile $path $url
+#     Write-Host "Downloading $binary_name ($arch architecture, $platform platform, version $version) to $path"
+#     Write-Host "🎉 Installation completed, path: $path_to_executable"
+# }
+
+# 定义清理函数
+function Cleanup {
+    if ($flag -eq 1) {
+        if (Test-Path -Path $path) {
+            Remove-Item -Path $path -Recurse -Force  # 删除路径及其内容
+            Write-Host "Deleted the path: $path"
+        }
+    }
+}
+
+# 注册退出事件
+Register-EngineEvent PowerShell.Exiting -Action { Cleanup }
+
+# 下载chsrc
+
+Get_Path 
+Get_Version
+Get_Url
+DownLoad

--- a/tool/install.ps1
+++ b/tool/install.ps1
@@ -128,8 +128,14 @@ function Get_Url {
     Write-Host "CPU Architecture: $global:arch"
 
     # Set URL
-    $global:url =  "https://gitee.com/RubyMetric/chsrc/releases/download/" + `
-                "v" + "${global:version}/chsrc-${global:arch}-windows.exe"
+    if ($version -eq "pre") {
+        $global:url =  "https://gitee.com/RubyMetric/chsrc/releases/download/" + `
+                            "${global:version}/chsrc-${global:arch}-windows.exe"
+    }
+    else {
+        $global:url =  "https://gitee.com/RubyMetric/chsrc/releases/download/" + `
+                            "v" + "${global:version}/chsrc-${global:arch}-windows.exe"
+    }
 
     Write-Host "DownLoad URL: $global:url."
 }

--- a/tool/install.ps1
+++ b/tool/install.ps1
@@ -128,7 +128,7 @@ function Get_Url {
 
     # Set URL
     $global:url =  "https://gitee.com/RubyMetric/chsrc/releases/download/" + `
-                "${global:version}/chsrc-${global:arch}-windows.exe"
+                "v" + "${global:version}/chsrc-${global:arch}-windows.exe"
 
     Write-Host "DownLoad URL: $global:url."
 }

--- a/tool/install.ps1
+++ b/tool/install.ps1
@@ -13,11 +13,11 @@
 param(
     [switch]
     $h,
-    $d = "${Home}\.chsrc\bin", 
+    $d = "${HOME}\Downloads", 
     $v = "pre"
 )
 $fileName = "\chsrc.exe"
-$default_path = "${Home}\.chsrc\bin"  
+$default_path = "${HOME}\Downloads"  
 $binary_name = "chsrc"
 $platform = "Windows"
 


### PR DESCRIPTION
## Overview of Changes
1. Add new feature to install.ps1.: use `-h` for help, `-d` for specifying directory, `-v` for specifying `chsrc` version.
2. Help output: use `-h` to display `help`.
3. Specify directory: default dir is `${HOME}\Downloads`,  can use `-d <dir>` to specify the download directory.
4. Specify chsrc version: default version is `pre`, use `-v <version>` to specify.
5. Rewrite the whole file, rebuild its structure.
6. Use English Output: to avoid scrambled code.

## Related Issues
Fixed #98 

## Type of Change
- [X] New feature
- [X] Code refactoring

## Impact
Now can use `install.ps1` on windows to download **any version** of chsrc in **any directory**.

## Test
I've already test the `-h`, `-v`, `-d` flag on my machine. `OS Version: Windows 10 Professional 64-bit`, `CPU Model: 12th Gen Intel(R) Core(TM) i7-12700H`. 

## Pretending Test
- [ ] didn't execute the script on `MacOS` or `Linux`. If you have the mechine mentioned above, plz do it.
- [ ] didn't test on `Windows 32-bit OS` and arch of `x86`.