### PR TITLE
Add some upstreams

### DIFF
--- a/src/recipe/lang/Rust/rustup.c
+++ b/src/recipe/lang/Rust/rustup.c
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  * -------------------------------------------------------------
  * File Authors  : Aoran Zeng <ccmywish@qq.com>
- * Contributors  :  Nil Null  <nil@null.org>
+ * Contributors  : Yangmoooo <yangmoooo@outlook.com>
  * Created On    : <2024-10-02>
  * Last Modified : <2024-10-02>
  * ------------------------------------------------------------*/

--- a/src/recipe/lang/Rust/rustup.c
+++ b/src/recipe/lang/Rust/rustup.c
@@ -12,7 +12,7 @@
  */
 static SourceInfo
 pl_rust_rustup_sources[] = {
-  {&Upstream,      NULL},
+  {&Upstream,      "https://static.rust-lang.org"},
   {&Tuna,          "https://mirrors.tuna.tsinghua.edu.cn/rustup"},
   {&Ustc,          "https://mirrors.ustc.edu.cn/rust-static"},
   {&Sjtug_Zhiyuan, "https://mirror.sjtu.edu.cn/rust-static"},

--- a/src/recipe/os/APT/Armbian.c
+++ b/src/recipe/os/APT/Armbian.c
@@ -12,7 +12,7 @@
  */
 static SourceInfo
 os_armbian_sources[] = {
-    {&Upstream,       NULL},
+    {&Upstream,      "http://apt.armbian.com"},
     {&Tuna,          "https://mirrors.tuna.tsinghua.edu.cn/armbian"},
     {&Sjtug_Zhiyuan, "https://mirror.sjtu.edu.cn/armbian"},
     {&Bfsu,          "https://mirrors.bfsu.edu.cn/armbian"},

--- a/src/recipe/os/APT/Armbian.c
+++ b/src/recipe/os/APT/Armbian.c
@@ -3,6 +3,7 @@
  * -------------------------------------------------------------
  * File Authors  : Shengwei Chen <414685209@qq.com>
  * Contributors  :  Aoran Zeng   <ccmywish@qq.com>
+ *               |  Yangmoooo <yangmoooo@outlook.com>
  * Created On    : <2024-06-14>
  * Last Modified : <2024-08-27>
  * ------------------------------------------------------------*/

--- a/src/recipe/os/APT/Debian.c
+++ b/src/recipe/os/APT/Debian.c
@@ -13,7 +13,7 @@
  */
 static SourceInfo
 os_debian_sources[] = {
-  {&Upstream,       NULL},
+  {&Upstream,      "http://deb.debian.org/debian"},
   {&Ali,           "https://mirrors.aliyun.com/debian"},
   {&Volcengine,    "https://mirrors.volces.com/debian"},
   {&Bfsu,          "https://mirrors.bfsu.edu.cn/debian"},

--- a/src/recipe/os/APT/Debian.c
+++ b/src/recipe/os/APT/Debian.c
@@ -3,7 +3,7 @@
  * -------------------------------------------------------------
  * File Authors  : Aoran Zeng <ccmywish@qq.com>
  *               |  Heng Guo  <2085471348@qq.com>
- * Contributors  :  Nil Null  <nil@null.org>
+ * Contributors  : Yangmoooo <yangmoooo@outlook.com>
  * Created On    : <2023-09-02>
  * Last Modified : <2024-10-31>
  * ------------------------------------------------------------*/

--- a/src/recipe/os/APT/Kali-Linux.c
+++ b/src/recipe/os/APT/Kali-Linux.c
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  * -------------------------------------------------------------
  * File Authors  :  Heng Guo  <2085471348@qq.com>
- * Contributors  :  Nil Null  <nil@null.org>
+ * Contributors  :  Yangmoooo <yangmoooo@outlook.com>
  * Created On    : <2023-09-29>
  * Last Modified : <2024-08-16>
  *

--- a/src/recipe/os/APT/Kali-Linux.c
+++ b/src/recipe/os/APT/Kali-Linux.c
@@ -14,7 +14,7 @@
  */
 static SourceInfo
 os_kali_sources[] = {
-  {&Upstream,       NULL},
+  {&Upstream,      "http://http.kali.org/kali"},
   {&Ali,           "https://mirrors.aliyun.com/kali"},
   {&Volcengine,    "https://mirrors.volces.com/kali"},
   {&Bfsu,          "https://mirrors.bfsu.edu.cn/kali"},

--- a/src/recipe/os/APT/Linux-Lite.c
+++ b/src/recipe/os/APT/Linux-Lite.c
@@ -12,7 +12,7 @@
  */
 static SourceInfo
 os_linuxlite_sources[] = {
-  {&Upstream,       NULL},
+  {&Upstream,       "http://repo.linuxliteos.com/linuxlite/"},
   {&Sjtug_Zhiyuan,  "https://mirrors.sjtug.sjtu.edu.cn/linuxliteos/"}
 };
 def_sources_n(os_linuxlite);

--- a/src/recipe/os/APT/Linux-Lite.c
+++ b/src/recipe/os/APT/Linux-Lite.c
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  * -------------------------------------------------------------
  * File Authors  : Aoran Zeng <ccmywish@qq.com>
- * Contributors  :  Nil Null  <nil@null.org>
+ * Contributors  : Yangmoooo <yangmoooo@outlook.com>
  * Created On    : <2023-09-29>
  * Last Modified : <2024-08-16>
  * ------------------------------------------------------------*/

--- a/src/recipe/os/APT/Raspberry-Pi-OS.c
+++ b/src/recipe/os/APT/Raspberry-Pi-OS.c
@@ -14,7 +14,7 @@
  */
 static SourceInfo
 os_raspberrypi_sources[] = {
-  {&Upstream,       NULL},
+  {&Upstream,       "https://archive.raspberrypi.com/"}, // https://archive.raspberrypi.org/ until Debian "bullseye" release
   {&MirrorZ,        "https://mirrors.cernet.edu.cn/raspberrypi/"},
   {&Tuna,           "https://mirrors.tuna.tsinghua.edu.cn/raspberrypi/"},
   {&Bfsu,           "https://mirrors.bfsu.edu.cn/raspberrypi/"},

--- a/src/recipe/os/APT/Raspberry-Pi-OS.c
+++ b/src/recipe/os/APT/Raspberry-Pi-OS.c
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  * -------------------------------------------------------------
  * File Authors  : Aoran Zeng <ccmywish@qq.com>
- * Contributors  :  Nil Null  <nil@null.org>
+ * Contributors  : Yangmoooo <yangmoooo@outlook.com>
  * Created On    : <2023-09-29>
  * Last Modified : <2024-10-02>
  *

--- a/src/recipe/os/APT/deepin.c
+++ b/src/recipe/os/APT/deepin.c
@@ -14,7 +14,7 @@
  */
 static SourceInfo
 os_deepin_sources[] = {
-  {&Upstream,       NULL},
+  {&Upstream,      "https://community-packages.deepin.com/deepin"},
   {&Ali,           "https://mirrors.aliyun.com/deepin"},
   {&Bfsu,          "https://mirrors.bfsu.edu.cn/deepin"},
   {&Ustc,          "https://mirrors.ustc.edu.cn/deepin"},

--- a/src/recipe/os/APT/deepin.c
+++ b/src/recipe/os/APT/deepin.c
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  * -------------------------------------------------------------
  * File Authors  :  Heng Guo  <2085471348@qq.com>
- * Contributors  :  Nil Null  <nil@null.org>
+ * Contributors  :  Yangmoooo <yangmoooo@outlook.com>
  * Created On    : <2023-09-26>
  * Last Modified : <2024-09-14>
  *

--- a/src/recipe/os/Alpine-Linux.c
+++ b/src/recipe/os/Alpine-Linux.c
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  * -------------------------------------------------------------
  * File Authors  : Aoran Zeng <ccmywish@qq.com>
- * Contributors  :  Nil Null  <nil@null.org>
+ * Contributors  : Yangmoooo <yangmoooo@outlook.com>
  * Created On    : <2023-09-24>
  * Last Modified : <2024-09-14>
  * ------------------------------------------------------------*/

--- a/src/recipe/os/Alpine-Linux.c
+++ b/src/recipe/os/Alpine-Linux.c
@@ -12,7 +12,7 @@
  */
 static SourceInfo
 os_alpine_sources[] = {
-  {&Upstream,       NULL},
+  {&Upstream,       "http://dl-cdn.alpinelinux.org/alpine"},
   {&Tuna,           "https://mirrors.tuna.tsinghua.edu.cn/alpine"},
   {&Sjtug_Zhiyuan,  "https://mirrors.sjtug.sjtu.edu.cn/alpine"},
   {&Sustech,        "https://mirrors.sustech.edu.cn/alpine"},

--- a/src/recipe/os/OpenWrt.c
+++ b/src/recipe/os/OpenWrt.c
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  * -------------------------------------------------------------
  * File Authors  : Aoran Zeng <ccmywish@qq.com>
- * Contributors  :  Nil Null  <nil@null.org>
+ * Contributors  : Yangmoooo <yangmoooo@outlook.com>
  * Created On    : <2024-08-08>
  * Last Modified : <2024-08-08>
  * ------------------------------------------------------------*/

--- a/src/recipe/os/OpenWrt.c
+++ b/src/recipe/os/OpenWrt.c
@@ -12,7 +12,7 @@
  */
 static SourceInfo
 os_openwrt_sources[] = {
-  {&Upstream,       NULL},
+  {&Upstream,       "http://downloads.openwrt.org"},
   {&MirrorZ,        "https://mirrors.cernet.edu.cn/openwrt"},
   {&Ali,            "https://mirrors.aliyun.com/openwrt"},
   {&Tencent,        "https://mirrors.cloud.tencent.com/openwrt"},

--- a/src/recipe/os/Void-Linux.c
+++ b/src/recipe/os/Void-Linux.c
@@ -12,7 +12,7 @@
  */
 static SourceInfo
 os_void_sources[] = {
-  {&Upstream,       NULL},
+  {&Upstream,       "https://repo-default.voidlinux.org"},
   {&Tuna,           "https://mirrors.tuna.tsinghua.edu.cn/voidlinux"},
   {&Sjtug_Zhiyuan,  "https://mirror.sjtu.edu.cn/voidlinux"},
   {&Bfsu,           "https://mirrors.bfsu.edu.cn/voidlinux"}

--- a/src/recipe/os/Void-Linux.c
+++ b/src/recipe/os/Void-Linux.c
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  * -------------------------------------------------------------
  * File Authors  : Aoran Zeng <ccmywish@qq.com>
- * Contributors  :  Nil Null  <nil@null.org>
+ * Contributors  : Yangmoooo <yangmoooo@outlook.com>
  * Created On    : <2023-09-24>
  * Last Modified : <2024-08-16>
  * ------------------------------------------------------------*/

--- a/src/recipe/os/YUM/AlmaLinux.c
+++ b/src/recipe/os/YUM/AlmaLinux.c
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  * -------------------------------------------------------------
  * File Authors  : Aoran Zeng <ccmywish@qq.com>
- * Contributors  :  Nil Null  <nil@null.org>
+ * Contributors  : Yangmoooo <yangmoooo@outlook.com>
  * Created On    : <2024-06-12>
  * Last Modified : <2024-08-16>
  * ------------------------------------------------------------*/

--- a/src/recipe/os/YUM/AlmaLinux.c
+++ b/src/recipe/os/YUM/AlmaLinux.c
@@ -12,7 +12,7 @@
  */
 static SourceInfo
 os_almalinux_sources[] = {
-  {&Upstream,       NULL},
+  {&Upstream,      "http://repo.almalinux.org/almalinux"},
   {&Ali,           "https://mirrors.aliyun.com/almalinux"},
   {&Volcengine,    "https://mirrors.volces.com/almalinux"},
   {&Sjtug_Zhiyuan, "https://mirrors.sjtug.sjtu.edu.cn/almalinux"},

--- a/src/recipe/os/YUM/openEuler.c
+++ b/src/recipe/os/YUM/openEuler.c
@@ -12,7 +12,7 @@
  */
 static SourceInfo
 os_openeuler_sources[] = {
-  {&Upstream,       NULL},
+  {&Upstream,       "https://repo.openeuler.org/"},
   {&Ali,            "https://mirrors.aliyun.com/openeuler/"},
   {&Bfsu,           "https://mirrors.bfsu.edu.cn/openeuler/"},
   {&Ustc,           "https://mirrors.ustc.edu.cn/openeuler/"},

--- a/src/recipe/os/YUM/openEuler.c
+++ b/src/recipe/os/YUM/openEuler.c
@@ -3,6 +3,7 @@
  * -------------------------------------------------------------
  * File Authors  :  Heng Guo  <2085471348@qq.com>
  * Contributors  : Aoran Zeng <ccmywish@qq.com>
+ *               | Yangmoooo <yangmoooo@outlook.com>
  * Created On    : <2023-09-06>
  * Last Modified : <2024-09-14>
  * ------------------------------------------------------------*/

--- a/src/recipe/ware/Anaconda.c
+++ b/src/recipe/ware/Anaconda.c
@@ -13,7 +13,7 @@
  */
 static SourceInfo
 wr_anaconda_sources[] = {
-  {&Upstream,       NULL},
+  {&Upstream,        "https://repo.anaconda.com/"},
   {&Tuna,            "https://mirrors.tuna.tsinghua.edu.cn/anaconda/"},
   {&Bfsu,            "https://mirrors.bfsu.edu.cn/anaconda/"},
   {&Zju,             "https://mirrors.zju.edu.cn/anaconda/"},

--- a/src/recipe/ware/Anaconda.c
+++ b/src/recipe/ware/Anaconda.c
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  * -------------------------------------------------------------
  * File Authors  : Aoran Zeng <ccmywish@qq.com>
- * Contributors  :  Nil Null  <nil@null.org>
+ * Contributors  : Yangmoooo <yangmoooo@outlook.com>
  * Created On    : <2023-09-10>
  * Last Modified : <2024-08-15>
  * ------------------------------------------------------------*/


### PR DESCRIPTION
Add upstream for `rustup`, `Armbian`, `Debian`, `Kali`, `Linux Lite`, `Raspberry Pi`, `deepin`, `Alpine`, `OpenWrt`, `Void Linux`, `AlmaLinux`, `openEuler` and `Anaconda`