### PR TITLE
Fix incorrect clang target parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ CFLAGS = -Iinclude # -Wall
 
 # 只有Windows会定义该变量
 ifeq ($(OS), Windows_NT)
-	CLANG_FLAGS = -Target x86_64-pc-windows-gnu
+	CLANG_FLAGS = -target x86_64-pc-windows-gnu
 endif
 ifeq ($(CC), clang)
 	CFLAGS += $(CLANG_FLAGS)


### PR DESCRIPTION
## Bug 背景

使用 `clang` 编译项目失败

## Bug 原因

`Makefile` 中 `clang` 在指定编译目标时使用的参数 `-Target` 错误，应为 `-target`

## 方案

改过来就好了，虽然后面的 `echo; echo` 在 Windows 上无法执行，但不影响编译