### PR TITLE
Support `uv` for Python

### DIFF
--- a/src/chsrc-main.c
+++ b/src/chsrc-main.c
@@ -21,7 +21,7 @@
  *                 |  yongxiang    <1926885268@qq.com>
  *                 |
  * Created On      : <2023-08-28>
- * Last Modified   : <2024-12-08>
+ * Last Modified   : <2024-12-11>
  *
  * chsrc: Change Source —— 全平台通用命令行换源工具
  * ------------------------------------------------------------*/
@@ -41,6 +41,7 @@
   #include "recipe/lang/Python/Poetry.c"
   #include "recipe/lang/Python/PDM.c"
   #include "recipe/lang/Python/Rye.c"
+  #include "recipe/lang/Python/uv.c"
 #include "recipe/lang/Python/Python.c"
 
 #include "recipe/lang/Node.js/common.h"

--- a/src/recipe/lang/Python/Python.c
+++ b/src/recipe/lang/Python/Python.c
@@ -2,20 +2,21 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  * -------------------------------------------------------------
  * File Authors  : Aoran Zeng <ccmywish@qq.com>
- * Contributors  :  Nil Null  <nil@null.org>
+ * Contributors  : happy game <happygame1024@gmail.com>
+ *               |
  * Created On    : <2023-09-03>
- * Last Modified : <2024-11-08>
+ * Last Modified : <2024-12-11>
  *
- * 2024-08-08: uv 似乎暂时没有实现换源
  * ------------------------------------------------------------*/
 
 void
 pl_python_getsrc (char *option)
 {
   bool pdm_exist    = false,
-       poetry_exist = false;
+       poetry_exist = false,
+       uv_exist     = false;
 
-  pl_python_check_unofficial_pkger (&poetry_exist, &pdm_exist);
+  pl_python_check_unofficial_pkger (&poetry_exist, &pdm_exist, &uv_exist);
 
   // 交给后面检查命令的存在性
   pl_python_pip_getsrc (option);
@@ -31,6 +32,11 @@ pl_python_getsrc (char *option)
     {
       pl_python_pdm_getsrc (option);
     }
+  
+  if (uv_exist)
+    {
+      pl_python_uv_getsrc (option);
+    }
 }
 
 
@@ -41,14 +47,15 @@ pl_python_setsrc (char *option)
     char *msg = CliOpt_InEnglish ? "Three package managers will be replaced for you at the same time: " \
                                          "pip, Poetry, PDM. If you need to change the source independently, " \
                                          "please run independently `chsrc set <pkg-manager>`"
-                                       : "将同时为您更换3个包管理器 pip, Poetry, PDM 的源，若需要独立换源，请独立运行 chsrc set <pkg-manager>";
+                                       : "将同时为您更换4个包管理器 pip, Poetry, PDM, uv 的源，若需要独立换源，请独立运行 chsrc set <pkg-manager>";
     chsrc_note2 (msg);
   }
 
   bool pdm_exist    = false,
-       poetry_exist = false;
+       poetry_exist = false,
+       uv_exist     = false;
 
-  pl_python_check_unofficial_pkger (&poetry_exist, &pdm_exist);
+  pl_python_check_unofficial_pkger (&poetry_exist, &pdm_exist, &uv_exist);
 
   ProgMode_Target_Group = true;
   chsrc_yield_source_and_confirm (pl_python);
@@ -67,6 +74,11 @@ pl_python_setsrc (char *option)
   if (pdm_exist)
     {
       pl_python_pdm_setsrc (option);
+    }
+  
+  if (uv_exist)
+    {
+      pl_python_uv_setsrc (option);
     }
 
   ProgMode_ChgType = ProgMode_CMD_Reset ? ChgType_Reset : ChgType_Auto;
@@ -89,7 +101,7 @@ pl_python_feat (char *option)
   f.can_reset = true;
 
   f.cap_locally = PartiallyCan;
-  f.cap_locally_explain = "Support `Poetry` & `PDM`. No support for `pip`";
+  f.cap_locally_explain = "Support `Poetry` & `PDM`, `uv`. No support for `pip`";
   f.can_english = false;
   f.can_user_define = true;
 

--- a/src/recipe/lang/Python/common.h
+++ b/src/recipe/lang/Python/common.h
@@ -3,10 +3,10 @@
  * -------------------------------------------------------------
  * File Authors   : Aoran Zeng <ccmywish@qq.com>
  * Contributors   : yongxiang  <1926885268@qq.com>
- *                |
+ *                | happy game <happygame1024@gmail.com>
  * Created On     : <2023-09-03>
  * Major Revision :      1
- * Last Modified  : <2024-12-08>
+ * Last Modified  : <2024-12-11>
  * ------------------------------------------------------------*/
 
 static SourceProvider_t UpstreamPython =
@@ -39,10 +39,11 @@ static Source_t pl_python_sources[] =
 def_sources_n(pl_python);
 
 void
-pl_python_check_unofficial_pkger (bool *poetry_exist, bool *pdm_exist)
+pl_python_check_unofficial_pkger (bool *poetry_exist, bool *pdm_exist, bool *uv_exist)
 {
   *poetry_exist = chsrc_check_program ("poetry");
   *pdm_exist = chsrc_check_program ("pdm");
+  *uv_exist = chsrc_check_program ("uv");
 }
 
 

--- a/src/recipe/lang/Python/uv.c
+++ b/src/recipe/lang/Python/uv.c
@@ -1,0 +1,138 @@
+/** ------------------------------------------------------------
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * -------------------------------------------------------------
+ * File Authors  : happy game <happygame1024@gmail.com>
+ * Contributors  :  Nul None  <nul@none.org>
+ * Created On    : <2024-12-11>
+ * Last Modified : <2024-12-11>
+ * ------------------------------------------------------------*/
+
+
+/**
+ * chsrc get uv
+ * uv的配置优先级顺序如下(高到低):
+ * 1. $workspaces/uv.toml
+ * 2. $workspaces/pyproject.toml
+ * 3. ~/.config/uv/uv.toml
+ * 4. /etc/uv/uv.toml
+ */
+
+#define UV_CONFIG "uv.toml"
+#define UV_LOCAL_CONFIG_PATH "./"
+#define UV_USER_CONFIG_PATH  "~/.config/uv/"
+
+
+char *
+pl_python_find_uv_config (bool mkdir)
+{
+  if (CliOpt_Locally)
+    {
+      return xy_strjoin (2, UV_LOCAL_CONFIG_PATH, UV_CONFIG);
+    }
+  else
+    {
+      if (mkdir)
+      {
+        chsrc_ensure_dir (UV_USER_CONFIG_PATH);
+      }
+      return xy_strjoin (2, UV_USER_CONFIG_PATH, UV_CONFIG);
+    }
+}
+
+void
+pl_python_uv_getsrc (char *option)
+{
+  char *uv_config = pl_python_find_uv_config (false);
+  if (!chsrc_check_file (uv_config))
+    {
+      chsrc_error2 ("未找到 uv 配置文件");
+      return;
+    }
+  // grep -A 2 'index' config_file | sed -n 's/^url = "\(.*\)"/\1/p'
+  // 获取 [[index]] 配置项的 url
+  char *cmd = xy_strjoin (3, "grep -A 2 'index' ",
+                             uv_config,
+                             " | sed -n 's/^url = \"\\(.*\\)\"/\\1/p'");
+  chsrc_run (cmd, RunOpt_Default);
+}
+
+
+/**
+ * @consult https://docs.astral.sh/uv/configuration/files/
+ *          https://github.com/RubyMetric/chsrc/issues/139
+ *
+ * chsrc set uv
+ */
+void
+pl_python_uv_setsrc (char *option)
+{
+  chsrc_ensure_program("uv");
+  
+  Source_t source;
+  chsrc_yield_for_the_source (pl_python);
+  
+  char *uv_config = pl_python_find_uv_config (true);
+  chsrc_backup (uv_config);
+  
+  const char *source_content = xy_strjoin (5,
+    "[[index]]\n",
+    "url = \"", source.url, "\"\n",
+    "default = true\n");
+  
+  // sed -i '/^\[\[index\]\]$/,/^default = true$/{s|^url = ".*"$|url = " source.url "|}' uv_config
+  // 将 [[index]] 到 default = true 之间的 url = ".*" 替换为 url = "source.url"
+  char *update_source_cmd = xy_strjoin (5, "sed -i ",
+                            "'/^\\[\\[index\\]\\]$/,/^default = true$/{s|^url = \".*\"$|url = \"",
+                            source.url, 
+                            "\"|}' ",
+                            uv_config);
+  
+  char *append_source_cmd = xy_strjoin (4, "echo -e '", source_content, "' >> ", uv_config);
+  
+  // grep -q '^[[index]]$' uv_config && update_source_cmd || append_source_cmd
+  // 如果 uv_config 中存在 [[index]] 则更新, 否则追加到文件末尾
+  // 文件不存在也是追加到新文件末尾
+  char *cmd = xy_strjoin (6, "grep -q '^\\[\\[index\\]\\]$' ",
+                             uv_config,
+                             " && ",
+                             update_source_cmd,
+                             " || ",
+                             append_source_cmd);
+  
+  chsrc_run (cmd, RunOpt_Default);
+}
+
+
+/**
+ * chsrc reset uv
+ */
+void
+pl_python_uv_resetsrc (char *option)
+{
+  pl_python_uv_setsrc (option);
+}
+
+
+/**
+ * chsrc ls uv
+ */
+Feature_t
+pl_python_uv_feat (char *option)
+{
+  Feature_t f = {0};
+
+  f.can_get = true;
+  f.can_reset = true;
+
+  f.cap_locally = true;
+  f.cap_locally_explain = NULL;
+
+  f.can_english = false;
+  f.can_user_define = true;
+
+  f.note = NULL;
+  return f;
+}
+
+// def_target_gsrf(pl_python_uv);
+Target_t pl_python_uv_target = {def_target_inner_gsrf(pl_python_uv),def_target_sourcesn(pl_python)};

--- a/src/recipe/menu.c
+++ b/src/recipe/menu.c
@@ -5,7 +5,7 @@
  * Contributors   :  Nil Null  <nil@null.org>
  * Created On     : <2023-09-01>
  * Major Revision :      1
- * Last Modified  : <2024-12-06>
+ * Last Modified  : <2024-12-11>
  * ------------------------------------------------------------*/
 
 /* Begin Target Matrix */
@@ -18,6 +18,7 @@ static const char
   *pl_python_poetry[] = {"poetry",                 NULL, t(&pl_python_poetry_target)},
   *pl_python_pdm[]    = {"pdm",                    NULL, t(&pl_python_pdm_target)},
   *pl_python_rye[]    = {"rye",                    NULL, t(&pl_python_rye_target)},
+  *pl_python_uv[]     = {"uv",                     NULL, t(&pl_python_uv_target)},
 
 *pl_nodejs[]        = {"node", "nodejs", NULL, t(&pl_nodejs_target)},
 *pl_nodejs_bun[]    = {"bun",            NULL, t(&pl_nodejs_bun_target)},
@@ -48,7 +49,7 @@ static const char
 **pl_packagers[] =
 {
   pl_ruby,
-  pl_python,  pl_python_pip, pl_python_poetry, pl_python_pdm, pl_python_rye,
+  pl_python,  pl_python_pip, pl_python_poetry, pl_python_pdm, pl_python_rye, pl_python_uv,
   pl_nodejs,  pl_nodejs_bun,
               pl_nodejs_npm, pl_nodejs_pnpm,   pl_nodejs_yarn,
               pl_nodejs_nvm,


### PR DESCRIPTION
- 实现了 `uv`的换源 #139 
- 将 `uv`添加进 `Python group`, 在 `chsrc set python`时一起换源