### PR TITLE
Support `get` `reset` `ls` for `openEuler` and measure upstream by default 

### DIFF
--- a/src/recipe/os/YUM/common.h
+++ b/src/recipe/os/YUM/common.h
@@ -3,11 +3,12 @@
  * -------------------------------------------------------------
  * File Authors  : Aoran Zeng <ccmywish@qq.com>
  * Contributors  :  Nil Null  <nil@null.org>
+ *               |
  * Created On    : <2024-08-16>
- * Last Modified : <2024-08-16>
+ * Last Modified : <2024-12-18>
  * ------------------------------------------------------------*/
 
 // #define OS_Yum_SourceList    "/etc/yum.repos"
 #define OS_Yum_SourceList_D     "/etc/yum.repos.d/"
 
-#define OS_openEuler_SourceList "openEuler.repo"
+#define OS_openEuler_SourceList OS_Yum_SourceList_D "openEuler.repo"

--- a/src/recipe/os/YUM/openEuler.c
+++ b/src/recipe/os/YUM/openEuler.c
@@ -34,8 +34,19 @@ static Source_t os_openeuler_sources[] =
 };
 def_sources_n(os_openeuler);
 
+
 /**
- * @update: 2024-12-18
+ * chsrc get openeuler
+ */
+void
+os_openeuler_getsrc (char *option)
+{
+  chsrc_view_file (OS_openEuler_SourceList);
+}
+
+
+/**
+ * chsrc set openeuler
  */
 void
 os_openeuler_setsrc (char *option)
@@ -44,7 +55,7 @@ os_openeuler_setsrc (char *option)
 
   chsrc_yield_source_and_confirm (os_openeuler);
 
-  chsrc_backup (OS_Yum_SourceList_D OS_openEuler_SourceList);
+  chsrc_backup (OS_openEuler_SourceList);
 
   // 替换 baseurl=<<URL>>/openEuler-xx.xx/...
   // openEuler-xx.xx 为 openEuler 版本号
@@ -54,7 +65,7 @@ os_openeuler_setsrc (char *option)
          source.url,
          "openEuler-\\1",
          "!g' ",
-         OS_Yum_SourceList_D OS_openEuler_SourceList);
+         OS_openEuler_SourceList);
   chsrc_run (cmd, RunOpt_Default);
 
   chsrc_run ("dnf makecache", RunOpt_No_Last_New_Line);
@@ -63,4 +74,4 @@ os_openeuler_setsrc (char *option)
   chsrc_conclude (&source);
 }
 
-def_target_s(os_openeuler);
+def_target_gs(os_openeuler);

--- a/src/recipe/os/YUM/openEuler.c
+++ b/src/recipe/os/YUM/openEuler.c
@@ -5,16 +5,24 @@
  * Contributors  : Aoran Zeng <ccmywish@qq.com>
  *               | Yangmoooo <yangmoooo@outlook.com>
  *               | happy game <happygame1024@gmail.com>
+ *               |
  * Created On    : <2023-09-06>
  * Last Modified : <2024-12-18>
  * ------------------------------------------------------------*/
 
+static SourceProvider_t os_Upstream_openEuler =
+{
+  "upstream", "https://repo.openeuler.org/", "上游默认源 https://repo.openeuler.org/", "https://repo.openeuler.org/",
+  {NotSkip, NA, NA, "https://repo.openeuler.org/openEuler-24.03-LTS/ISO/x86_64/openEuler-24.03-LTS-netinst-x86_64-dvd.iso"} // 896MB
+};
+
+
 /**
- * @update 2024-09-14
+ * @update 2024-12-18
  */
 static Source_t os_openeuler_sources[] =
 {
-  {&UpstreamProvider, "https://repo.openeuler.org/"},
+  {&os_Upstream_openEuler, "https://repo.openeuler.org/"},
   {&Ali,              "https://mirrors.aliyun.com/openeuler/"},
   {&Bfsu,             "https://mirrors.bfsu.edu.cn/openeuler/"},
   {&Ustc,             "https://mirrors.ustc.edu.cn/openeuler/"},
@@ -38,7 +46,7 @@ os_openeuler_setsrc (char *option)
 
   chsrc_backup (OS_Yum_SourceList_D OS_openEuler_SourceList);
 
-  // 替换 baseurl=<<URL>>/openEuler-xx.xx/... 
+  // 替换 baseurl=<<URL>>/openEuler-xx.xx/...
   // openEuler-xx.xx 为 openEuler 版本号
   // sed -E 's!^baseurl=.*?/openEuler-([^/]+)!baseurl=source.url/openEuler-\1/!g' OS_openEuler_SourceList
   char* cmd = xy_strjoin (6, "sed ",

--- a/src/recipe/os/YUM/openEuler.c
+++ b/src/recipe/os/YUM/openEuler.c
@@ -74,4 +74,15 @@ os_openeuler_setsrc (char *option)
   chsrc_conclude (&source);
 }
 
-def_target_gs(os_openeuler);
+
+/**
+ * chsrc reset openeuler
+ */
+void
+os_openeuler_resetsrc (char *option)
+{
+  os_openeuler_setsrc (option);
+}
+
+
+def_target_gsr(os_openeuler);

--- a/src/recipe/os/YUM/openEuler.c
+++ b/src/recipe/os/YUM/openEuler.c
@@ -85,4 +85,25 @@ os_openeuler_resetsrc (char *option)
 }
 
 
-def_target_gsr(os_openeuler);
+/**
+ * chsrc ls openeuler
+ */
+Feature_t
+os_openeuler_feat (char *option)
+{
+  Feature_t f = {0};
+
+  f.can_get = true;
+  f.can_reset = true;
+
+  f.cap_locally = CanNot;
+  f.cap_locally_explain = NULL;
+  f.can_english = true;
+  f.can_user_define = true;
+
+  f.note = NULL;
+
+  return f;
+}
+
+def_target_gsrf(os_openeuler);


### PR DESCRIPTION
### 描述

- **问题的背景**  
 
   对 `openEuler` 提供完善的支持

- **相关Issue**  
  
    #156

- **这个PR做了什么**  

    - 默认对上游源测速
    - 添加了 `get` 的支持
    - 添加了 `reset` 的支持
    - 添加了 `ls` 的支持

---

### 方案

上游源测试地址来自于：https://repo.openeuler.org/openEuler-24.03-LTS/ISO/x86_64/

我找了一个大小合适的链接供测速

---

### 实现

实现很直接，不再赘述

---

### 注意

无特别注意事项

---

### 测试

```bash
chsrc measure openeuler
chsrc get openeuler
chsrc reset openeuler
chsrc ls openeuler
```

---
