### PR TITLE
Fix README and segmentation fault for FreeBSD, addressing #163

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ curl -L https://gitee.com/RubyMetric/chsrc/releases/download/pre/chsrc-x64-macos
 
 ```bash
 $ git clone https://gitee.com/RubyMetric/chsrc.git; cd chsrc
-$ clang -Iinclude src/chsrc-main.c -o chsrc
+$ clang -Iinclude -Ilib src/chsrc-main.c -o chsrc
 ```
 </details>
 

--- a/lib/xy.h
+++ b/lib/xy.h
@@ -5,7 +5,7 @@
  * Lib Name      : xy.h
  * Lib Authors   : Aoran Zeng <ccmywish@qq.com>
  *               |  Heng Guo  <2085471348@qq.com>
- * Contributors  :  Nil Null  <nil@null.org>
+ * Contributors  :   juzeon   <skyjuzheng@gmail.com>
  *               |
  * Created On    : <2023-08-28>
  * Last Modified : <2024-12-14>
@@ -642,7 +642,7 @@ xy_run_iter (const char *cmd,  unsigned long n,  void (*iter_func) (const char *
 static char *
 xy_run (const char *cmd, unsigned long n)
 {
-  xy_run_iter (cmd, n, NULL);
+  return xy_run_iter (cmd, n, NULL);
 }
 
 

--- a/src/chsrc-main.c
+++ b/src/chsrc-main.c
@@ -20,6 +20,7 @@
  *                 |    zouri      <guoshuaisun@outlook.com>
  *                 |  yongxiang    <1926885268@qq.com>
  *                 |    YU-7       <2747046473@qq.com>
+ *                 |   juzeon      <skyjuzheng@gmail.com>
  *                 |
  * Created On      : <2023-08-28>
  * Last Modified   : <2024-12-25>


### PR DESCRIPTION
## 描述

### 问题的背景

Fix README and segmentation fault for FreeBSD, addressing #163

All credits to @ccmywish

### 相关 issue

- Closes #163

### 这个PR做了什么

修改README，增加-Ilib；修复xy_run()

```c
static char *
xy_run (const char *cmd, unsigned long n)
{
  // 少了一个 return
  xy_run_iter (cmd, n, NULL);
}
```

---

## 方案

如上

---

## 实现

如上

---

## 测试

```bash
./chsrc set freebsd first
```
