### PR TITLE
Fix `flathub` chsrc

### DIFF
--- a/src/chsrc-main.c
+++ b/src/chsrc-main.c
@@ -21,6 +21,7 @@
  *                 |  yongxiang    <1926885268@qq.com>
  *                 |    YU-7       <2747046473@qq.com>
  *                 |   juzeon      <skyjuzheng@gmail.com>
+ *                 | Jialin Lyu    <jialinlvcn@aliyun.com>
  *                 |
  * Created On      : <2023-08-28>
  * Last Modified   : <2025-03-14>

--- a/src/framework/mirror.c
+++ b/src/framework/mirror.c
@@ -12,211 +12,223 @@
  * 通用镜像站
  * ------------------------------------------------------------*/
 
-#define Big_File_ubuntu     "/18.04/ubuntu-18.04.6-desktop-amd64.iso"       // 2.3 GB
-#define Big_File_ctan       "/systems/texlive/Images/texlive.iso"           // 4.8 GB
-#define Big_File_archlinux  "/iso/latest/archlinux-x86_64.iso"              // 800 MB
-#define Big_File_deepin     "/20.9/deepin-desktop-community-20.9-amd64.iso" // 4 GB
-
-/**
- * 教育网镜像
- *
- * @sync https://github.com/RubyMetric/chsrc/wiki
- *
- * Wiki中的排序是根据 https://github.com/mirrorz-org/oh-my-mirrorz 挑选速度前10位
+ #define Big_File_ubuntu     "/18.04/ubuntu-18.04.6-desktop-amd64.iso"       // 2.3 GB
+ #define Big_File_ctan       "/systems/texlive/Images/texlive.iso"           // 4.8 GB
+ #define Big_File_archlinux  "/iso/latest/archlinux-x86_64.iso"              // 800 MB
+ #define Big_File_deepin     "/20.9/deepin-desktop-community-20.9-amd64.iso" // 4 GB
+ 
+ /**
+  * 教育网镜像
+  *
+  * @sync https://github.com/RubyMetric/chsrc/wiki
+  *
+  * Wiki中的排序是根据 https://github.com/mirrorz-org/oh-my-mirrorz 挑选速度前10位
+  */
+ MirrorSite_t MirrorZ =
+ {
+   "mirrorz", "MirrorZ",  "MirrorZ 校园网镜像站", "https://mirrors.cernet.edu.cn/",
+   {SKIP, "功能特殊无法测速，跳过", "SKIP because of its special function"}
+ },
+ 
+ Tuna =
+ {
+   "tuna", "TUNA", "清华大学开源软件镜像站", "https://mirrors.tuna.tsinghua.edu.cn/",
+   {NotSkip, NA, NA, "https://mirrors.tuna.tsinghua.edu.cn/speedtest/1000mb.bin"}
+ },
+ 
+ /**
+  * @note 2025-3-17 SJTUG 共设两台服务器。思源服务器同步新镜像，致远服务器兼容原 SJTU 镜像站。
+  * @note 有些target（例如flathub）思源站的兼容性不好，可以考虑将两个服务器分开测试
+  */
+ 
+ Sjtug_Zhiyuan =
+ {
+   "sjtu", "SJTUG-zhiyuan", "上海交通大学致远镜像站", "https://mirrors.sjtug.sjtu.edu.cn/",
+   {NotSkip, NA, NA, "https://mirrors.sjtug.sjtu.edu.cn/ctan" Big_File_ctan}
+ },
+ 
+ Sjtug_Siyuan =
+ {
+   "sjtu", "SJTUG-siyuan", "上海交通大学思源镜像站", "https://mirror.sjtu.edu.cn/",
+   {NotSkip, NA, NA, "https://mirror.sjtu.edu.cn/ctan" Big_File_ctan}
+ },
+ 
+ Zju =
+ {
+   "zju", "ZJU", "浙江大学开源软件镜像站", "https://mirrors.zju.edu.cn/",
+   {NotSkip, NA, NA, "https://mirrors.zju.edu.cn/ubuntu-releases" Big_File_ubuntu}
+ },
+ 
+ Lzuoss =
+ {
+   "lzu", "LZUOSS", "兰州大学开源社区镜像站", "https://mirror.lzu.edu.cn/",
+   {NotSkip, NA, NA, "https://mirror.lzu.edu.cn/CTAN" Big_File_ctan}
+ },
+ 
+ Jlu =
+ {
+   "jlu", "JLU", "吉林大学开源镜像站", "https://mirrors.jlu.edu.cn/",
+   {NotSkip, NA, NA, "https://mirrors.jlu.edu.cn/_static/speedtest.bin"}
+ },
+ 
+ Bfsu =
+ {
+   "bfsu", "BFSU", "北京外国语大学开源软件镜像站", "https://mirrors.bfsu.edu.cn/",
+   {NotSkip, NA, NA, "https://mirrors.bfsu.edu.cn/speedtest/1000mb.bin"}
+ },
+ 
+ Pku =
+ {
+   "pku", "PKU", "北京大学开源镜像站", "https://mirrors.pku.edu.cn/",
+   {NotSkip, NA, NA, "https://mirrors.pku.edu.cn/ubuntu-releases" Big_File_ubuntu}
+ },
+ 
+ Bjtu =
+ {
+   "bjtu", "BJTU", "北京交通大学自由与开源软件镜像站", "https://mirror.bjtu.edu.cn/",
+   {NotSkip, NA, NA, "https://mirror.bjtu.edu.cn/archlinux" Big_File_archlinux}
+ },
+ 
+ Sustech =
+ {
+   "sustech", "SUSTech", "南方科技大学开源软件镜像站", "https://mirrors.sustech.edu.cn/",
+   {NotSkip, NA, NA, "https://mirrors.sustech.edu.cn/site/speedtest/1000mb.bin"}
+ },
+ 
+ Ustc =
+ {
+   "ustc", "USTC", "中国科学技术大学开源镜像站", "https://mirrors.ustc.edu.cn/",
+   {NotSkip, NA, NA, "https://mirrors.ustc.edu.cn/ubuntu-releases" Big_File_ubuntu}
+ },
+ 
+ Hust =
+ {
+   "hust", "HUST", "华中科技大学开源镜像站", "https://mirrors.hust.edu.cn/",
+   {NotSkip, NA, NA, "https://mirrors.hust.edu.cn/ubuntu-releases" Big_File_ubuntu}
+ },
+ 
+ // 速度暂时处于10位以后或者无测速报告，但是目前可用的源
+ 
+ Iscas =
+ {
+   "iscas", "ISCAS", "中科院软件所智能软件研究中心开源镜像站", "https://mirror.iscas.ac.cn/",
+   {NotSkip, NA, NA, "https://mirror.iscas.ac.cn/ubuntu-releases" Big_File_ubuntu}
+ },
+ 
+ Scau =
+ {
+   "scau", "SCAU", "华南农业大学开源软件镜像站", "https://mirrors.scau.edu.cn/",
+   {NotSkip, NA, NA, "https://mirrors.scau.edu.cn/ubuntu-releases" Big_File_ubuntu}
+ },
+ 
+ NJTech =
+ {
+   "njtech", "NJTech", "南京工业大学开源软件镜像站", "https://mirrors.njtech.edu.cn/",
+   {NotSkip, NA, NA, "https://mirrors.njtech.edu.cn/ubuntu-releases" Big_File_ubuntu}
+ },
+ 
+ Nyist =
+ {
+   "nyist", "NYIST", "南阳理工学院开源软件镜像站", "https://mirror.nyist.edu.cn/",
+   {NotSkip, NA, NA, "https://mirror.nyist.edu.cn/ubuntu-releases" Big_File_ubuntu}
+ },
+ 
+ Sdu =
+ {
+   "sdu", "SDU", "山东大学镜像站", "https://mirrors.sdu.edu.cn/",
+   {NotSkip, NA, NA, "https://mirrors.sdu.edu.cn/ubuntu-releases" Big_File_ubuntu}
+ },
+ 
+ Cqupt =
+ {
+   "cqupt", "CQUPT", "重庆邮电大学开源镜像站", "https://mirrors.cqupt.edu.cn/",
+   {NotSkip, NA, NA, "https://mirrors.cqupt.edu.cn/ubuntu-releases" Big_File_ubuntu}
+ },
+ 
+ Nju =
+ {
+   "nju", "NJU", "南京大学开源镜像站", "https://mirrors.nju.edu.cn/",
+   {NotSkip, NA, NA, "https://mirrors.nju.edu.cn/archlinux" Big_File_archlinux}
+ };
+ 
+ /**
+  * @note 2023-09-05 只使用了不到5次，重庆大学镜像站就把我的ip封杀了，对用户来说封杀策略过严，暂时不可靠，暂时不用
+  *
+  * Cqu =
+  * {
+  *   "cqu", "CQU", "重庆大学开源软件镜像站", "https://mirrors.cqu.edu.cn/",
+  *   {NotSkip, NA, NA, "https://mirrors.cqu.edu.cn/speedtest/1000mb.bin"}
+  * };
+  *
+  */
+ 
+ 
+ 
+ /**
+  * 商业公司提供的源
+  */
+ MirrorSite_t Ali =
+ {
+   "ali", "Ali OPSX Public", "阿里巴巴开源镜像站(公网)", "https://developer.aliyun.com/mirror/",
+   {NotSkip, NA, NA, "https://mirrors.aliyun.com/deepin-cd" Big_File_deepin}
+ },
+ /*
+ // https://mirrors.cloud.aliyuncs.com/
+ Ali_ECS_VPC =
+ {
+   "ali-ECS-VPC", "Ali OPSX ECS VPC", "阿里巴巴开源镜像站(ECS VPC网络)", "https://developer.aliyun.com/mirror/",
+   {NotSkip, NA, NA, "https://mirrors.cloud.aliyuncs.com/deepin-cd" Big_File_deepin}
+ },
+ 
+ // https://mirrors.aliyuncs.com/
+ Ali_ECS_classic =
+ {
+   "ali-ECS", "Ali OPSX ECS", "阿里巴巴开源镜像站(ECS 经典网络)", "https://developer.aliyun.com/mirror/",
+   {NotSkip, NA, NA, "https://mirrors.aliyuncs.com/deepin-cd" Big_File_deepin}
+ },
  */
-MirrorSite_t MirrorZ =
-{
-  "mirrorz", "MirrorZ",  "MirrorZ 校园网镜像站", "https://mirrors.cernet.edu.cn/",
-  {SKIP, "功能特殊无法测速，跳过", "SKIP because of its special function"}
-},
-
-Tuna =
-{
-  "tuna", "TUNA", "清华大学开源软件镜像站", "https://mirrors.tuna.tsinghua.edu.cn/",
-  {NotSkip, NA, NA, "https://mirrors.tuna.tsinghua.edu.cn/speedtest/1000mb.bin"}
-},
-
-Sjtug_Zhiyuan =
-{
-  "sjtu", "SJTUG-zhiyuan", "上海交通大学致远镜像站", "https://mirrors.sjtug.sjtu.edu.cn/",
-  {NotSkip, NA, NA, "https://mirrors.sjtug.sjtu.edu.cn/ctan" Big_File_ctan}
-},
-
-Zju =
-{
-  "zju", "ZJU", "浙江大学开源软件镜像站", "https://mirrors.zju.edu.cn/",
-  {NotSkip, NA, NA, "https://mirrors.zju.edu.cn/ubuntu-releases" Big_File_ubuntu}
-},
-
-Lzuoss =
-{
-  "lzu", "LZUOSS", "兰州大学开源社区镜像站", "https://mirror.lzu.edu.cn/",
-  {NotSkip, NA, NA, "https://mirror.lzu.edu.cn/CTAN" Big_File_ctan}
-},
-
-Jlu =
-{
-  "jlu", "JLU", "吉林大学开源镜像站", "https://mirrors.jlu.edu.cn/",
-  {NotSkip, NA, NA, "https://mirrors.jlu.edu.cn/_static/speedtest.bin"}
-},
-
-Bfsu =
-{
-  "bfsu", "BFSU", "北京外国语大学开源软件镜像站", "https://mirrors.bfsu.edu.cn/",
-  {NotSkip, NA, NA, "https://mirrors.bfsu.edu.cn/speedtest/1000mb.bin"}
-},
-
-Pku =
-{
-  "pku", "PKU", "北京大学开源镜像站", "https://mirrors.pku.edu.cn/",
-  {NotSkip, NA, NA, "https://mirrors.pku.edu.cn/ubuntu-releases" Big_File_ubuntu}
-},
-
-Bjtu =
-{
-  "bjtu", "BJTU", "北京交通大学自由与开源软件镜像站", "https://mirror.bjtu.edu.cn/",
-  {NotSkip, NA, NA, "https://mirror.bjtu.edu.cn/archlinux" Big_File_archlinux}
-},
-
-Sustech =
-{
-  "sustech", "SUSTech", "南方科技大学开源软件镜像站", "https://mirrors.sustech.edu.cn/",
-  {NotSkip, NA, NA, "https://mirrors.sustech.edu.cn/site/speedtest/1000mb.bin"}
-},
-
-Ustc =
-{
-  "ustc", "USTC", "中国科学技术大学开源镜像站", "https://mirrors.ustc.edu.cn/",
-  {NotSkip, NA, NA, "https://mirrors.ustc.edu.cn/ubuntu-releases" Big_File_ubuntu}
-},
-
-Hust =
-{
-  "hust", "HUST", "华中科技大学开源镜像站", "https://mirrors.hust.edu.cn/",
-  {NotSkip, NA, NA, "https://mirrors.hust.edu.cn/ubuntu-releases" Big_File_ubuntu}
-},
-
-// 速度暂时处于10位以后或者无测速报告，但是目前可用的源
-
-Iscas =
-{
-  "iscas", "ISCAS", "中科院软件所智能软件研究中心开源镜像站", "https://mirror.iscas.ac.cn/",
-  {NotSkip, NA, NA, "https://mirror.iscas.ac.cn/ubuntu-releases" Big_File_ubuntu}
-},
-
-Scau =
-{
-  "scau", "SCAU", "华南农业大学开源软件镜像站", "https://mirrors.scau.edu.cn/",
-  {NotSkip, NA, NA, "https://mirrors.scau.edu.cn/ubuntu-releases" Big_File_ubuntu}
-},
-
-NJTech =
-{
-  "njtech", "NJTech", "南京工业大学开源软件镜像站", "https://mirrors.njtech.edu.cn/",
-  {NotSkip, NA, NA, "https://mirrors.njtech.edu.cn/ubuntu-releases" Big_File_ubuntu}
-},
-
-Nyist =
-{
-  "nyist", "NYIST", "南阳理工学院开源软件镜像站", "https://mirror.nyist.edu.cn/",
-  {NotSkip, NA, NA, "https://mirror.nyist.edu.cn/ubuntu-releases" Big_File_ubuntu}
-},
-
-Sdu =
-{
-  "sdu", "SDU", "山东大学镜像站", "https://mirrors.sdu.edu.cn/",
-  {NotSkip, NA, NA, "https://mirrors.sdu.edu.cn/ubuntu-releases" Big_File_ubuntu}
-},
-
-Cqupt =
-{
-  "cqupt", "CQUPT", "重庆邮电大学开源镜像站", "https://mirrors.cqupt.edu.cn/",
-  {NotSkip, NA, NA, "https://mirrors.cqupt.edu.cn/ubuntu-releases" Big_File_ubuntu}
-},
-
-Nju =
-{
-  "nju", "NJU", "南京大学开源镜像站", "https://mirrors.nju.edu.cn/",
-  {NotSkip, NA, NA, "https://mirrors.nju.edu.cn/archlinux" Big_File_archlinux}
-};
-
-/**
- * @note 2023-09-05 只使用了不到5次，重庆大学镜像站就把我的ip封杀了，对用户来说封杀策略过严，暂时不可靠，暂时不用
- *
- * Cqu =
- * {
- *   "cqu", "CQU", "重庆大学开源软件镜像站", "https://mirrors.cqu.edu.cn/",
- *   {NotSkip, NA, NA, "https://mirrors.cqu.edu.cn/speedtest/1000mb.bin"}
- * };
- *
+ 
+ Tencent =
+ {
+   "tencent", "Tencent Public", "腾讯软件源(公网)", "https://mirrors.tencent.com/",
+   {NotSkip, NA, NA, "https://mirrors.cloud.tencent.com/ubuntu-releases" Big_File_ubuntu}
+ },
+ /*
+ Tencent_Intra =
+ {
+   "tencent-intra", "Tencent Intranet",  "腾讯软件源(内网)", "https://mirrors.tencent.com/",
+   {NotSkip, NA, NA, "https://mirrors.cloud.tencentyun.com/ubuntu-releases" Big_File_ubuntu}
+ },
  */
-
-
-
-/**
- * 商业公司提供的源
+ 
+ Huawei =
+ {
+   "huawei",  "Huawei Cloud", "华为开源镜像站",  "https://mirrors.huaweicloud.com/",
+   {NotSkip, NA, NA, "https://mirrors.huaweicloud.com/ubuntu-releases" Big_File_ubuntu}
+ },
+ 
+ Volcengine =
+ {
+   "volc", "Volcengine", "火山引擎开源软件镜像站(公网)", "https://developer.volcengine.com/mirror/",
+   {NotSkip, NA, NA, "https://mirrors.volces.com/ubuntu-releases" Big_File_ubuntu}
+ },
+ /*
+ Volceengine_Intra =
+ {
+   "volc-intra",  "Volcengine Intranet", "火山引擎开源软件镜像站(内网)",
+   "https://developer.volcengine.com/mirror/",
+   "https://mirrors.ivolces.com/ubuntu-releases" Big_File_ubuntu },
  */
-MirrorSite_t Ali =
-{
-  "ali", "Ali OPSX Public", "阿里巴巴开源镜像站(公网)", "https://developer.aliyun.com/mirror/",
-  {NotSkip, NA, NA, "https://mirrors.aliyun.com/deepin-cd" Big_File_deepin}
-},
-/*
-// https://mirrors.cloud.aliyuncs.com/
-Ali_ECS_VPC =
-{
-  "ali-ECS-VPC", "Ali OPSX ECS VPC", "阿里巴巴开源镜像站(ECS VPC网络)", "https://developer.aliyun.com/mirror/",
-  {NotSkip, NA, NA, "https://mirrors.cloud.aliyuncs.com/deepin-cd" Big_File_deepin}
-},
-
-// https://mirrors.aliyuncs.com/
-Ali_ECS_classic =
-{
-  "ali-ECS", "Ali OPSX ECS", "阿里巴巴开源镜像站(ECS 经典网络)", "https://developer.aliyun.com/mirror/",
-  {NotSkip, NA, NA, "https://mirrors.aliyuncs.com/deepin-cd" Big_File_deepin}
-},
-*/
-
-Tencent =
-{
-  "tencent", "Tencent Public", "腾讯软件源(公网)", "https://mirrors.tencent.com/",
-  {NotSkip, NA, NA, "https://mirrors.cloud.tencent.com/ubuntu-releases" Big_File_ubuntu}
-},
-/*
-Tencent_Intra =
-{
-  "tencent-intra", "Tencent Intranet",  "腾讯软件源(内网)", "https://mirrors.tencent.com/",
-  {NotSkip, NA, NA, "https://mirrors.cloud.tencentyun.com/ubuntu-releases" Big_File_ubuntu}
-},
-*/
-
-Huawei =
-{
-  "huawei",  "Huawei Cloud", "华为开源镜像站",  "https://mirrors.huaweicloud.com/",
-  {NotSkip, NA, NA, "https://mirrors.huaweicloud.com/ubuntu-releases" Big_File_ubuntu}
-},
-
-Volcengine =
-{
-  "volc", "Volcengine", "火山引擎开源软件镜像站(公网)", "https://developer.volcengine.com/mirror/",
-  {NotSkip, NA, NA, "https://mirrors.volces.com/ubuntu-releases" Big_File_ubuntu}
-},
-/*
-Volceengine_Intra =
-{
-  "volc-intra",  "Volcengine Intranet", "火山引擎开源软件镜像站(内网)",
-  "https://developer.volcengine.com/mirror/",
-  "https://mirrors.ivolces.com/ubuntu-releases" Big_File_ubuntu },
-*/
-
-Netease =
-{
-  "netease", "Netease", "网易开源镜像站", "https://mirrors.163.com/",
-  {NotSkip, NA, NA, "https://mirrors.163.com/deepin-cd" Big_File_deepin}
-},
-
-Sohu =
-{
-  "sohu", "SOHU", "搜狐开源镜像站", "https://mirrors.sohu.com/",
-  {NotSkip, NA, NA, "https://mirrors.sohu.com/deepin-cd" Big_File_deepin}
-};
+ 
+ Netease =
+ {
+   "netease", "Netease", "网易开源镜像站", "https://mirrors.163.com/",
+   {NotSkip, NA, NA, "https://mirrors.163.com/deepin-cd" Big_File_deepin}
+ },
+ 
+ Sohu =
+ {
+   "sohu", "SOHU", "搜狐开源镜像站", "https://mirrors.sohu.com/",
+   {NotSkip, NA, NA, "https://mirrors.sohu.com/deepin-cd" Big_File_deepin}
+ };
+ 

--- a/src/framework/mirror.c
+++ b/src/framework/mirror.c
@@ -36,10 +36,21 @@ Tuna =
   {NotSkip, NA, NA, "https://mirrors.tuna.tsinghua.edu.cn/speedtest/1000mb.bin"}
 },
 
+/**
+ * @note 2025-3-17 SJTUG 共设两台服务器。思源服务器同步新镜像，致远服务器兼容原 SJTU 镜像站。
+ * @note 有些target（例如flathub）思源站的兼容性不好，可以考虑将两个服务器分开测试
+ */
+
 Sjtug_Zhiyuan =
 {
   "sjtu", "SJTUG-zhiyuan", "上海交通大学致远镜像站", "https://mirrors.sjtug.sjtu.edu.cn/",
   {NotSkip, NA, NA, "https://mirrors.sjtug.sjtu.edu.cn/ctan" Big_File_ctan}
+},
+
+Sjtug_Siyuan =
+{
+  "sjtu", "SJTUG-siyuan", "上海交通大学思源镜像站", "https://mirror.sjtu.edu.cn/",
+  {NotSkip, NA, NA, "https://mirror.sjtu.edu.cn/ctan" Big_File_ctan}
 },
 
 Zju =

--- a/src/framework/mirror.c
+++ b/src/framework/mirror.c
@@ -5,6 +5,7 @@
  * File Authors  :  Aoran Zeng   <ccmywish@qq.com>
  *               |   Heng Guo    <2085471348@qq.com>
  * Contributors  : Shengwei Chen <414685209@qq.com>
+ *               |  Jialin Lyu   <jialinlvcn@aliyun.com>
  *               |
  * Created On    : <2023-08-29>
  * Last Modified : <2025-03-09>

--- a/src/framework/mirror.c
+++ b/src/framework/mirror.c
@@ -12,223 +12,211 @@
  * 通用镜像站
  * ------------------------------------------------------------*/
 
- #define Big_File_ubuntu     "/18.04/ubuntu-18.04.6-desktop-amd64.iso"       // 2.3 GB
- #define Big_File_ctan       "/systems/texlive/Images/texlive.iso"           // 4.8 GB
- #define Big_File_archlinux  "/iso/latest/archlinux-x86_64.iso"              // 800 MB
- #define Big_File_deepin     "/20.9/deepin-desktop-community-20.9-amd64.iso" // 4 GB
- 
- /**
-  * 教育网镜像
-  *
-  * @sync https://github.com/RubyMetric/chsrc/wiki
-  *
-  * Wiki中的排序是根据 https://github.com/mirrorz-org/oh-my-mirrorz 挑选速度前10位
-  */
- MirrorSite_t MirrorZ =
- {
-   "mirrorz", "MirrorZ",  "MirrorZ 校园网镜像站", "https://mirrors.cernet.edu.cn/",
-   {SKIP, "功能特殊无法测速，跳过", "SKIP because of its special function"}
- },
- 
- Tuna =
- {
-   "tuna", "TUNA", "清华大学开源软件镜像站", "https://mirrors.tuna.tsinghua.edu.cn/",
-   {NotSkip, NA, NA, "https://mirrors.tuna.tsinghua.edu.cn/speedtest/1000mb.bin"}
- },
- 
- /**
-  * @note 2025-3-17 SJTUG 共设两台服务器。思源服务器同步新镜像，致远服务器兼容原 SJTU 镜像站。
-  * @note 有些target（例如flathub）思源站的兼容性不好，可以考虑将两个服务器分开测试
-  */
- 
- Sjtug_Zhiyuan =
- {
-   "sjtu", "SJTUG-zhiyuan", "上海交通大学致远镜像站", "https://mirrors.sjtug.sjtu.edu.cn/",
-   {NotSkip, NA, NA, "https://mirrors.sjtug.sjtu.edu.cn/ctan" Big_File_ctan}
- },
- 
- Sjtug_Siyuan =
- {
-   "sjtu", "SJTUG-siyuan", "上海交通大学思源镜像站", "https://mirror.sjtu.edu.cn/",
-   {NotSkip, NA, NA, "https://mirror.sjtu.edu.cn/ctan" Big_File_ctan}
- },
- 
- Zju =
- {
-   "zju", "ZJU", "浙江大学开源软件镜像站", "https://mirrors.zju.edu.cn/",
-   {NotSkip, NA, NA, "https://mirrors.zju.edu.cn/ubuntu-releases" Big_File_ubuntu}
- },
- 
- Lzuoss =
- {
-   "lzu", "LZUOSS", "兰州大学开源社区镜像站", "https://mirror.lzu.edu.cn/",
-   {NotSkip, NA, NA, "https://mirror.lzu.edu.cn/CTAN" Big_File_ctan}
- },
- 
- Jlu =
- {
-   "jlu", "JLU", "吉林大学开源镜像站", "https://mirrors.jlu.edu.cn/",
-   {NotSkip, NA, NA, "https://mirrors.jlu.edu.cn/_static/speedtest.bin"}
- },
- 
- Bfsu =
- {
-   "bfsu", "BFSU", "北京外国语大学开源软件镜像站", "https://mirrors.bfsu.edu.cn/",
-   {NotSkip, NA, NA, "https://mirrors.bfsu.edu.cn/speedtest/1000mb.bin"}
- },
- 
- Pku =
- {
-   "pku", "PKU", "北京大学开源镜像站", "https://mirrors.pku.edu.cn/",
-   {NotSkip, NA, NA, "https://mirrors.pku.edu.cn/ubuntu-releases" Big_File_ubuntu}
- },
- 
- Bjtu =
- {
-   "bjtu", "BJTU", "北京交通大学自由与开源软件镜像站", "https://mirror.bjtu.edu.cn/",
-   {NotSkip, NA, NA, "https://mirror.bjtu.edu.cn/archlinux" Big_File_archlinux}
- },
- 
- Sustech =
- {
-   "sustech", "SUSTech", "南方科技大学开源软件镜像站", "https://mirrors.sustech.edu.cn/",
-   {NotSkip, NA, NA, "https://mirrors.sustech.edu.cn/site/speedtest/1000mb.bin"}
- },
- 
- Ustc =
- {
-   "ustc", "USTC", "中国科学技术大学开源镜像站", "https://mirrors.ustc.edu.cn/",
-   {NotSkip, NA, NA, "https://mirrors.ustc.edu.cn/ubuntu-releases" Big_File_ubuntu}
- },
- 
- Hust =
- {
-   "hust", "HUST", "华中科技大学开源镜像站", "https://mirrors.hust.edu.cn/",
-   {NotSkip, NA, NA, "https://mirrors.hust.edu.cn/ubuntu-releases" Big_File_ubuntu}
- },
- 
- // 速度暂时处于10位以后或者无测速报告，但是目前可用的源
- 
- Iscas =
- {
-   "iscas", "ISCAS", "中科院软件所智能软件研究中心开源镜像站", "https://mirror.iscas.ac.cn/",
-   {NotSkip, NA, NA, "https://mirror.iscas.ac.cn/ubuntu-releases" Big_File_ubuntu}
- },
- 
- Scau =
- {
-   "scau", "SCAU", "华南农业大学开源软件镜像站", "https://mirrors.scau.edu.cn/",
-   {NotSkip, NA, NA, "https://mirrors.scau.edu.cn/ubuntu-releases" Big_File_ubuntu}
- },
- 
- NJTech =
- {
-   "njtech", "NJTech", "南京工业大学开源软件镜像站", "https://mirrors.njtech.edu.cn/",
-   {NotSkip, NA, NA, "https://mirrors.njtech.edu.cn/ubuntu-releases" Big_File_ubuntu}
- },
- 
- Nyist =
- {
-   "nyist", "NYIST", "南阳理工学院开源软件镜像站", "https://mirror.nyist.edu.cn/",
-   {NotSkip, NA, NA, "https://mirror.nyist.edu.cn/ubuntu-releases" Big_File_ubuntu}
- },
- 
- Sdu =
- {
-   "sdu", "SDU", "山东大学镜像站", "https://mirrors.sdu.edu.cn/",
-   {NotSkip, NA, NA, "https://mirrors.sdu.edu.cn/ubuntu-releases" Big_File_ubuntu}
- },
- 
- Cqupt =
- {
-   "cqupt", "CQUPT", "重庆邮电大学开源镜像站", "https://mirrors.cqupt.edu.cn/",
-   {NotSkip, NA, NA, "https://mirrors.cqupt.edu.cn/ubuntu-releases" Big_File_ubuntu}
- },
- 
- Nju =
- {
-   "nju", "NJU", "南京大学开源镜像站", "https://mirrors.nju.edu.cn/",
-   {NotSkip, NA, NA, "https://mirrors.nju.edu.cn/archlinux" Big_File_archlinux}
- };
- 
- /**
-  * @note 2023-09-05 只使用了不到5次，重庆大学镜像站就把我的ip封杀了，对用户来说封杀策略过严，暂时不可靠，暂时不用
-  *
-  * Cqu =
-  * {
-  *   "cqu", "CQU", "重庆大学开源软件镜像站", "https://mirrors.cqu.edu.cn/",
-  *   {NotSkip, NA, NA, "https://mirrors.cqu.edu.cn/speedtest/1000mb.bin"}
-  * };
-  *
-  */
- 
- 
- 
- /**
-  * 商业公司提供的源
-  */
- MirrorSite_t Ali =
- {
-   "ali", "Ali OPSX Public", "阿里巴巴开源镜像站(公网)", "https://developer.aliyun.com/mirror/",
-   {NotSkip, NA, NA, "https://mirrors.aliyun.com/deepin-cd" Big_File_deepin}
- },
- /*
- // https://mirrors.cloud.aliyuncs.com/
- Ali_ECS_VPC =
- {
-   "ali-ECS-VPC", "Ali OPSX ECS VPC", "阿里巴巴开源镜像站(ECS VPC网络)", "https://developer.aliyun.com/mirror/",
-   {NotSkip, NA, NA, "https://mirrors.cloud.aliyuncs.com/deepin-cd" Big_File_deepin}
- },
- 
- // https://mirrors.aliyuncs.com/
- Ali_ECS_classic =
- {
-   "ali-ECS", "Ali OPSX ECS", "阿里巴巴开源镜像站(ECS 经典网络)", "https://developer.aliyun.com/mirror/",
-   {NotSkip, NA, NA, "https://mirrors.aliyuncs.com/deepin-cd" Big_File_deepin}
- },
+#define Big_File_ubuntu     "/18.04/ubuntu-18.04.6-desktop-amd64.iso"       // 2.3 GB
+#define Big_File_ctan       "/systems/texlive/Images/texlive.iso"           // 4.8 GB
+#define Big_File_archlinux  "/iso/latest/archlinux-x86_64.iso"              // 800 MB
+#define Big_File_deepin     "/20.9/deepin-desktop-community-20.9-amd64.iso" // 4 GB
+
+/**
+ * 教育网镜像
+ *
+ * @sync https://github.com/RubyMetric/chsrc/wiki
+ *
+ * Wiki中的排序是根据 https://github.com/mirrorz-org/oh-my-mirrorz 挑选速度前10位
  */
- 
- Tencent =
- {
-   "tencent", "Tencent Public", "腾讯软件源(公网)", "https://mirrors.tencent.com/",
-   {NotSkip, NA, NA, "https://mirrors.cloud.tencent.com/ubuntu-releases" Big_File_ubuntu}
- },
- /*
- Tencent_Intra =
- {
-   "tencent-intra", "Tencent Intranet",  "腾讯软件源(内网)", "https://mirrors.tencent.com/",
-   {NotSkip, NA, NA, "https://mirrors.cloud.tencentyun.com/ubuntu-releases" Big_File_ubuntu}
- },
+MirrorSite_t MirrorZ =
+{
+  "mirrorz", "MirrorZ",  "MirrorZ 校园网镜像站", "https://mirrors.cernet.edu.cn/",
+  {SKIP, "功能特殊无法测速，跳过", "SKIP because of its special function"}
+},
+
+Tuna =
+{
+  "tuna", "TUNA", "清华大学开源软件镜像站", "https://mirrors.tuna.tsinghua.edu.cn/",
+  {NotSkip, NA, NA, "https://mirrors.tuna.tsinghua.edu.cn/speedtest/1000mb.bin"}
+},
+
+Sjtug_Zhiyuan =
+{
+  "sjtu", "SJTUG-zhiyuan", "上海交通大学致远镜像站", "https://mirrors.sjtug.sjtu.edu.cn/",
+  {NotSkip, NA, NA, "https://mirrors.sjtug.sjtu.edu.cn/ctan" Big_File_ctan}
+},
+
+Zju =
+{
+  "zju", "ZJU", "浙江大学开源软件镜像站", "https://mirrors.zju.edu.cn/",
+  {NotSkip, NA, NA, "https://mirrors.zju.edu.cn/ubuntu-releases" Big_File_ubuntu}
+},
+
+Lzuoss =
+{
+  "lzu", "LZUOSS", "兰州大学开源社区镜像站", "https://mirror.lzu.edu.cn/",
+  {NotSkip, NA, NA, "https://mirror.lzu.edu.cn/CTAN" Big_File_ctan}
+},
+
+Jlu =
+{
+  "jlu", "JLU", "吉林大学开源镜像站", "https://mirrors.jlu.edu.cn/",
+  {NotSkip, NA, NA, "https://mirrors.jlu.edu.cn/_static/speedtest.bin"}
+},
+
+Bfsu =
+{
+  "bfsu", "BFSU", "北京外国语大学开源软件镜像站", "https://mirrors.bfsu.edu.cn/",
+  {NotSkip, NA, NA, "https://mirrors.bfsu.edu.cn/speedtest/1000mb.bin"}
+},
+
+Pku =
+{
+  "pku", "PKU", "北京大学开源镜像站", "https://mirrors.pku.edu.cn/",
+  {NotSkip, NA, NA, "https://mirrors.pku.edu.cn/ubuntu-releases" Big_File_ubuntu}
+},
+
+Bjtu =
+{
+  "bjtu", "BJTU", "北京交通大学自由与开源软件镜像站", "https://mirror.bjtu.edu.cn/",
+  {NotSkip, NA, NA, "https://mirror.bjtu.edu.cn/archlinux" Big_File_archlinux}
+},
+
+Sustech =
+{
+  "sustech", "SUSTech", "南方科技大学开源软件镜像站", "https://mirrors.sustech.edu.cn/",
+  {NotSkip, NA, NA, "https://mirrors.sustech.edu.cn/site/speedtest/1000mb.bin"}
+},
+
+Ustc =
+{
+  "ustc", "USTC", "中国科学技术大学开源镜像站", "https://mirrors.ustc.edu.cn/",
+  {NotSkip, NA, NA, "https://mirrors.ustc.edu.cn/ubuntu-releases" Big_File_ubuntu}
+},
+
+Hust =
+{
+  "hust", "HUST", "华中科技大学开源镜像站", "https://mirrors.hust.edu.cn/",
+  {NotSkip, NA, NA, "https://mirrors.hust.edu.cn/ubuntu-releases" Big_File_ubuntu}
+},
+
+// 速度暂时处于10位以后或者无测速报告，但是目前可用的源
+
+Iscas =
+{
+  "iscas", "ISCAS", "中科院软件所智能软件研究中心开源镜像站", "https://mirror.iscas.ac.cn/",
+  {NotSkip, NA, NA, "https://mirror.iscas.ac.cn/ubuntu-releases" Big_File_ubuntu}
+},
+
+Scau =
+{
+  "scau", "SCAU", "华南农业大学开源软件镜像站", "https://mirrors.scau.edu.cn/",
+  {NotSkip, NA, NA, "https://mirrors.scau.edu.cn/ubuntu-releases" Big_File_ubuntu}
+},
+
+NJTech =
+{
+  "njtech", "NJTech", "南京工业大学开源软件镜像站", "https://mirrors.njtech.edu.cn/",
+  {NotSkip, NA, NA, "https://mirrors.njtech.edu.cn/ubuntu-releases" Big_File_ubuntu}
+},
+
+Nyist =
+{
+  "nyist", "NYIST", "南阳理工学院开源软件镜像站", "https://mirror.nyist.edu.cn/",
+  {NotSkip, NA, NA, "https://mirror.nyist.edu.cn/ubuntu-releases" Big_File_ubuntu}
+},
+
+Sdu =
+{
+  "sdu", "SDU", "山东大学镜像站", "https://mirrors.sdu.edu.cn/",
+  {NotSkip, NA, NA, "https://mirrors.sdu.edu.cn/ubuntu-releases" Big_File_ubuntu}
+},
+
+Cqupt =
+{
+  "cqupt", "CQUPT", "重庆邮电大学开源镜像站", "https://mirrors.cqupt.edu.cn/",
+  {NotSkip, NA, NA, "https://mirrors.cqupt.edu.cn/ubuntu-releases" Big_File_ubuntu}
+},
+
+Nju =
+{
+  "nju", "NJU", "南京大学开源镜像站", "https://mirrors.nju.edu.cn/",
+  {NotSkip, NA, NA, "https://mirrors.nju.edu.cn/archlinux" Big_File_archlinux}
+};
+
+/**
+ * @note 2023-09-05 只使用了不到5次，重庆大学镜像站就把我的ip封杀了，对用户来说封杀策略过严，暂时不可靠，暂时不用
+ *
+ * Cqu =
+ * {
+ *   "cqu", "CQU", "重庆大学开源软件镜像站", "https://mirrors.cqu.edu.cn/",
+ *   {NotSkip, NA, NA, "https://mirrors.cqu.edu.cn/speedtest/1000mb.bin"}
+ * };
+ *
  */
- 
- Huawei =
- {
-   "huawei",  "Huawei Cloud", "华为开源镜像站",  "https://mirrors.huaweicloud.com/",
-   {NotSkip, NA, NA, "https://mirrors.huaweicloud.com/ubuntu-releases" Big_File_ubuntu}
- },
- 
- Volcengine =
- {
-   "volc", "Volcengine", "火山引擎开源软件镜像站(公网)", "https://developer.volcengine.com/mirror/",
-   {NotSkip, NA, NA, "https://mirrors.volces.com/ubuntu-releases" Big_File_ubuntu}
- },
- /*
- Volceengine_Intra =
- {
-   "volc-intra",  "Volcengine Intranet", "火山引擎开源软件镜像站(内网)",
-   "https://developer.volcengine.com/mirror/",
-   "https://mirrors.ivolces.com/ubuntu-releases" Big_File_ubuntu },
+
+
+
+/**
+ * 商业公司提供的源
  */
- 
- Netease =
- {
-   "netease", "Netease", "网易开源镜像站", "https://mirrors.163.com/",
-   {NotSkip, NA, NA, "https://mirrors.163.com/deepin-cd" Big_File_deepin}
- },
- 
- Sohu =
- {
-   "sohu", "SOHU", "搜狐开源镜像站", "https://mirrors.sohu.com/",
-   {NotSkip, NA, NA, "https://mirrors.sohu.com/deepin-cd" Big_File_deepin}
- };
- 
+MirrorSite_t Ali =
+{
+  "ali", "Ali OPSX Public", "阿里巴巴开源镜像站(公网)", "https://developer.aliyun.com/mirror/",
+  {NotSkip, NA, NA, "https://mirrors.aliyun.com/deepin-cd" Big_File_deepin}
+},
+/*
+// https://mirrors.cloud.aliyuncs.com/
+Ali_ECS_VPC =
+{
+  "ali-ECS-VPC", "Ali OPSX ECS VPC", "阿里巴巴开源镜像站(ECS VPC网络)", "https://developer.aliyun.com/mirror/",
+  {NotSkip, NA, NA, "https://mirrors.cloud.aliyuncs.com/deepin-cd" Big_File_deepin}
+},
+
+// https://mirrors.aliyuncs.com/
+Ali_ECS_classic =
+{
+  "ali-ECS", "Ali OPSX ECS", "阿里巴巴开源镜像站(ECS 经典网络)", "https://developer.aliyun.com/mirror/",
+  {NotSkip, NA, NA, "https://mirrors.aliyuncs.com/deepin-cd" Big_File_deepin}
+},
+*/
+
+Tencent =
+{
+  "tencent", "Tencent Public", "腾讯软件源(公网)", "https://mirrors.tencent.com/",
+  {NotSkip, NA, NA, "https://mirrors.cloud.tencent.com/ubuntu-releases" Big_File_ubuntu}
+},
+/*
+Tencent_Intra =
+{
+  "tencent-intra", "Tencent Intranet",  "腾讯软件源(内网)", "https://mirrors.tencent.com/",
+  {NotSkip, NA, NA, "https://mirrors.cloud.tencentyun.com/ubuntu-releases" Big_File_ubuntu}
+},
+*/
+
+Huawei =
+{
+  "huawei",  "Huawei Cloud", "华为开源镜像站",  "https://mirrors.huaweicloud.com/",
+  {NotSkip, NA, NA, "https://mirrors.huaweicloud.com/ubuntu-releases" Big_File_ubuntu}
+},
+
+Volcengine =
+{
+  "volc", "Volcengine", "火山引擎开源软件镜像站(公网)", "https://developer.volcengine.com/mirror/",
+  {NotSkip, NA, NA, "https://mirrors.volces.com/ubuntu-releases" Big_File_ubuntu}
+},
+/*
+Volceengine_Intra =
+{
+  "volc-intra",  "Volcengine Intranet", "火山引擎开源软件镜像站(内网)",
+  "https://developer.volcengine.com/mirror/",
+  "https://mirrors.ivolces.com/ubuntu-releases" Big_File_ubuntu },
+*/
+
+Netease =
+{
+  "netease", "Netease", "网易开源镜像站", "https://mirrors.163.com/",
+  {NotSkip, NA, NA, "https://mirrors.163.com/deepin-cd" Big_File_deepin}
+},
+
+Sohu =
+{
+  "sohu", "SOHU", "搜狐开源镜像站", "https://mirrors.sohu.com/",
+  {NotSkip, NA, NA, "https://mirrors.sohu.com/deepin-cd" Big_File_deepin}
+};

--- a/src/recipe/ware/Flathub.c
+++ b/src/recipe/ware/Flathub.c
@@ -4,17 +4,38 @@
  * File Authors  : Aoran Zeng <ccmywish@qq.com>
  * Contributors  :  Nil Null  <nil@null.org>
  * Created On    : <2023-09-11>
- * Last Modified : <2024-08-15>
+ * Last Modified : <2025-03-17>
  * ------------------------------------------------------------*/
 
 /**
- * @update 2023-09-11
- * @note 目前只有一个源
+ * @update 2025-03-17
+ * @note 加入官方仓库
+ * @note SJTUG分为两个镜像站 思源站和致远站 以解决思源站可能无法访问的问题
  */
+static SourceProvider_t wr_flathub_upstream =
+{
+  "Flathub", "Flathub", "Flathub官方仓库", "https://flathub.org/repo",
+  // 没有找到 DaoCloud 合适的下载链接，先随便给一个，以规避 chsrc 自动测速时所有 dockerhub 镜像站都没有测速链接带来的 bug
+  {NotSkip, NA, NA, "https://flathub.org/repo/flathub.gpg"}
+},
+
+wr_flathub_siyuan =
+{
+  "sjtu", "SJTUG-siyuan", "上海交通大学思源镜像站Flathub", "https://mirror.sjtu.edu.cn/",
+  {NotSkip, NA, NA, "https://mirror.sjtu.edu.cn/flathub/flathub.gpg"}
+},
+
+wr_flathub_zhiyuan =
+{
+  "sjtu", "SJTUG-zhiyuan", "上海交通大学致远镜像站Flathub", "https://mirrors.sjtug.sjtu.edu.cn/",
+  {NotSkip, NA, NA, "https://mirrors.sjtug.sjtu.edu.cn/flathub/flathub.gpg"}
+};
+
 static Source_t wr_flathub_sources[] =
 {
-  {&UpstreamProvider,  NULL},
-  {&Sjtug_Zhiyuan,    "https://mirror.sjtu.edu.cn/flathub"},
+  {&wr_flathub_upstream, "https://flathub.org/repo"},
+  {&wr_flathub_siyuan,    "https://mirror.sjtu.edu.cn/flathub"},
+  {&wr_flathub_zhiyuan,    "https://mirrors.sjtug.sjtu.edu.cn/flathub"},
 };
 def_sources_n(wr_flathub);
 
@@ -33,6 +54,11 @@ wr_flathub_setsrc (char *option)
     "flatpak remote-modify --gpg-import=flathub.gpg flathub"
   );
   puts (note);
+
+  char *repo_note = "Flathub 中部分软件由于重分发授权问题，需要从官方服务器下载，无法使用镜像站加速\n"
+    "比如 NVIDIA 驱动、JetBrains 系列软件等\n"
+    "尝试运行 flatpak remote-modify flathub --url=https://flathub.org/repo";
+  puts (repo_note);
 
   char *cmd = xy_2strjoin ("flatpak remote-modify flathub --url=", source.url);
   chsrc_run (cmd, RunOpt_Default);

--- a/src/recipe/ware/Flathub.c
+++ b/src/recipe/ware/Flathub.c
@@ -2,50 +2,26 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  * -------------------------------------------------------------
  * File Authors  : Aoran Zeng <ccmywish@qq.com>
- * Contributors  : Jialin Lyu  <jialinlvcn@aliyun.com>
+ * Contributors  :  Nil Null  <nil@null.org>
  * Created On    : <2023-09-11>
- * Last Modified : <2025-03-17>
+ * Last Modified : <2024-08-15>
  * ------------------------------------------------------------*/
 
 /**
  * @update 2023-09-11
  * @note 目前只有一个源
- * @update 2025-03-17
- * @note 加入官方仓库
- * @note SJTUG分为两个镜像站 思源站和致远站 以解决思源站可能无法访问的问题
  */
+static Source_t wr_flathub_sources[] =
+{
+  {&UpstreamProvider,  NULL},
+  {&Sjtug_Zhiyuan,    "https://mirror.sjtu.edu.cn/flathub"},
+};
+def_sources_n(wr_flathub);
 
 
 /**
  * @consult https://mirrors.sjtug.sjtu.edu.cn/docs/flathub
  */
-static MirrorSite_t UpstreamFlathub =
-{
-  "Flathub", "Flathub", "Flathub官方仓库", "https://flathub.org/repo",
-  // 没有找到 DaoCloud 合适的下载链接，先随便给一个，以规避 chsrc 自动测速时所有 dockerhub 镜像站都没有测速链接带来的 bug
-  {NotSkip, NA, NA, "https://flathub.org/repo/flathub.gpg"}
-},
-
-Sjtug_Siyuan_Flathub =
-{
-  "sjtu", "SJTUG-siyuan", "上海交通大学思源镜像站Flathub", "https://mirror.sjtu.edu.cn/",
-  {NotSkip, NA, NA, "https://mirror.sjtu.edu.cn/flathub/flathub.gpg"}
-},
-
-Sjtug_Zhiyuan_Flathub =
-{
-  "sjtu", "SJTUG-zhiyuan", "上海交通大学致远镜像站Flathub", "https://mirrors.sjtug.sjtu.edu.cn/",
-  {NotSkip, NA, NA, "https://mirrors.sjtug.sjtu.edu.cn/flathub/flathub.gpg"}
-};
-
-static Source_t wr_flathub_sources[] =
-{
-  {&UpstreamFlathub,  "https://flathub.org/repo"},
-  {&Sjtug_Siyuan_Flathub,    "https://mirror.sjtu.edu.cn/flathub"},
-  {&Sjtug_Zhiyuan_Flathub,    "https://mirrors.sjtug.sjtu.edu.cn/flathub"},
-};
-def_sources_n(wr_flathub);
-
 void
 wr_flathub_setsrc (char *option)
 {
@@ -57,13 +33,6 @@ wr_flathub_setsrc (char *option)
     "flatpak remote-modify --gpg-import=flathub.gpg flathub"
   );
   puts (note);
-
-  char *repo_note = xy_strjoin (1,
-    "Flathub 中部分软件由于重分发授权问题，需要从官方服务器下载，无法使用镜像站加速\n"
-    "比如 NVIDIA 驱动、JetBrains 系列软件等\n"
-    "尝试运行 flatpak remote-modify flathub --url=https://flathub.org/repo"
-  );
-  puts (repo_note);
 
   char *cmd = xy_2strjoin ("flatpak remote-modify flathub --url=", source.url);
   chsrc_run (cmd, RunOpt_Default);

--- a/src/recipe/ware/Flathub.c
+++ b/src/recipe/ware/Flathub.c
@@ -2,26 +2,50 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  * -------------------------------------------------------------
  * File Authors  : Aoran Zeng <ccmywish@qq.com>
- * Contributors  :  Nil Null  <nil@null.org>
+ * Contributors  : Jialin Lyu  <jialinlvcn@aliyun.com>
  * Created On    : <2023-09-11>
- * Last Modified : <2024-08-15>
+ * Last Modified : <2025-03-17>
  * ------------------------------------------------------------*/
 
 /**
  * @update 2023-09-11
  * @note 目前只有一个源
+ * @update 2025-03-17
+ * @note 加入官方仓库
+ * @note SJTUG分为两个镜像站 思源站和致远站 以解决思源站可能无法访问的问题
  */
-static Source_t wr_flathub_sources[] =
-{
-  {&UpstreamProvider,  NULL},
-  {&Sjtug_Zhiyuan,    "https://mirror.sjtu.edu.cn/flathub"},
-};
-def_sources_n(wr_flathub);
 
 
 /**
  * @consult https://mirrors.sjtug.sjtu.edu.cn/docs/flathub
  */
+static MirrorSite_t UpstreamFlathub =
+{
+  "Flathub", "Flathub", "Flathub官方仓库", "https://flathub.org/repo",
+  // 没有找到 DaoCloud 合适的下载链接，先随便给一个，以规避 chsrc 自动测速时所有 dockerhub 镜像站都没有测速链接带来的 bug
+  {NotSkip, NA, NA, "https://flathub.org/repo/flathub.gpg"}
+},
+
+Sjtug_Siyuan_Flathub =
+{
+  "sjtu", "SJTUG-siyuan", "上海交通大学思源镜像站Flathub", "https://mirror.sjtu.edu.cn/",
+  {NotSkip, NA, NA, "https://mirror.sjtu.edu.cn/flathub/flathub.gpg"}
+},
+
+Sjtug_Zhiyuan_Flathub =
+{
+  "sjtu", "SJTUG-zhiyuan", "上海交通大学致远镜像站Flathub", "https://mirrors.sjtug.sjtu.edu.cn/",
+  {NotSkip, NA, NA, "https://mirrors.sjtug.sjtu.edu.cn/flathub/flathub.gpg"}
+};
+
+static Source_t wr_flathub_sources[] =
+{
+  {&UpstreamFlathub,  "https://flathub.org/repo"},
+  {&Sjtug_Siyuan_Flathub,    "https://mirror.sjtu.edu.cn/flathub"},
+  {&Sjtug_Zhiyuan_Flathub,    "https://mirrors.sjtug.sjtu.edu.cn/flathub"},
+};
+def_sources_n(wr_flathub);
+
 void
 wr_flathub_setsrc (char *option)
 {
@@ -33,6 +57,13 @@ wr_flathub_setsrc (char *option)
     "flatpak remote-modify --gpg-import=flathub.gpg flathub"
   );
   puts (note);
+
+  char *repo_note = xy_strjoin (1,
+    "Flathub 中部分软件由于重分发授权问题，需要从官方服务器下载，无法使用镜像站加速\n"
+    "比如 NVIDIA 驱动、JetBrains 系列软件等\n"
+    "尝试运行 flatpak remote-modify flathub --url=https://flathub.org/repo"
+  );
+  puts (repo_note);
 
   char *cmd = xy_2strjoin ("flatpak remote-modify flathub --url=", source.url);
   chsrc_run (cmd, RunOpt_Default);

--- a/src/recipe/ware/Flathub.c
+++ b/src/recipe/ware/Flathub.c
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  * -------------------------------------------------------------
  * File Authors  : Aoran Zeng <ccmywish@qq.com>
- * Contributors  :  Nil Null  <nil@null.org>
+ * Contributors  : Jialin Lyu <jialinlvcn@aliyun.com>
  * Created On    : <2023-09-11>
  * Last Modified : <2025-03-17>
  * ------------------------------------------------------------*/


### PR DESCRIPTION
## 描述
### 问题的背景
- 近期`Flathub`上海交通大学镜像站存在不兼容的问题
### 相关 issue
- #178 

### 这个PR做了什么
- 修复了`Ware Flathub`换源
- 在`mirror.c`中区分了上海交通大学思源镜像站和致远镜像站
- 添加Flathub官方仓库

## 方案
### 实现
- 添加了`Flathub.c`中用于测试的`MirrorSite_t`和对应的测试链接
### 测试
- 运行 chsrc set flathub
