### PR TITLE
fix #177: fails without error when publishing chsrc-bin to AUR

### DIFF
--- a/.github/workflows/pkg-aur-git.yml
+++ b/.github/workflows/pkg-aur-git.yml
@@ -15,7 +15,7 @@ jobs:
       run: |
         wget https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD\?h\=chsrc-git -O ./PKGBUILD
     - name: Publish to AUR
-      uses: KSXGitHub/github-actions-deploy-aur@v3.0.1
+      uses: KSXGitHub/github-actions-deploy-aur@v4.1.1
       with:
         pkgname: chsrc-git
         pkgbuild: ./PKGBUILD

--- a/.github/workflows/pkg-aur-rel.yml
+++ b/.github/workflows/pkg-aur-rel.yml
@@ -33,7 +33,7 @@ jobs:
         sed -i "s/pkgver=.*/pkgver=$version/" PKGBUILD_bin
     - name: Publish chsrc-bin to AUR
       if: env.valid == '1'
-      uses: KSXGitHub/github-actions-deploy-aur@v3.0.1
+      uses: KSXGitHub/github-actions-deploy-aur@v4.1.1
       with:
         pkgname: chsrc-bin
         pkgbuild: ./PKGBUILD_bin
@@ -51,7 +51,7 @@ jobs:
         sed -i "s/pkgver=.*/pkgver=$version/" PKGBUILD
     - name: Publish chsrc to AUR
       if: env.valid == '1'
-      uses: KSXGitHub/github-actions-deploy-aur@v3.0.1
+      uses: KSXGitHub/github-actions-deploy-aur@v4.1.1
       with:
         pkgname: chsrc
         pkgbuild: ./PKGBUILD


### PR DESCRIPTION
## 描述

### 问题的背景

#177 `chsrc-bin` 未正常发布但没有报错。

经排查，是由于上游Action `KSXGitHub/github-actions-deploy-aur@3.0.1` 在`pkgbuild`参数对应的文件名不是默认的`PKGBUILD`时（此处为`./PKGBUILD_bin`），不会使用提供的文件替换目标仓库中的`PKGBUILD` [ref](https://github.com/KSXGitHub/github-actions-deploy-aur/issues/44) 。这一问题导致了发布更新时始终错误地使用了旧版本的`PKGBUILD`文件，并且没有错误提示。

### 相关 issue

- 解决： #177 
- 上游问题： https://github.com/KSXGitHub/github-actions-deploy-aur/issues/44
- 上游已修复： https://github.com/KSXGitHub/github-actions-deploy-aur/pull/45

### 这个PR做了什么

更新使用的上游Action至 `KSXGitHub/github-actions-deploy-aur@4.1.1`。