### PR TITLE
Fix: upgrade bash installer

### DIFF
--- a/tool/installer.sh
+++ b/tool/installer.sh
@@ -26,6 +26,7 @@ tmp_created_install_dir=""
 userOpt_version="pre"
 userOpt_help=0
 userOpt_lang="zh"
+version_prefix="v"
 
 
 
@@ -164,6 +165,11 @@ install() {
       else
         error "Unsupported version: ${userOpt_version}. Version number must be 0.x.y (>=0.1.4) or 'pre'"
       fi
+  fi
+
+  # version 版本不是 'pre'，添加'v'前缀
+  if [[ "$userOpt_version" =~ ^(0\.([1-9])\.([0-9]))$ ]]; then
+    userOpt_version="${version_prefix}${userOpt_version}"
   fi
 
   url="https://gitee.com/RubyMetric/chsrc/releases/download/${userOpt_version}/${binary_name}-${arch}-${platform}"


### PR DESCRIPTION
## 描述

### 问题的背景

bash脚本在0.x.y类型的版本中无法正确构造URL，缺少前缀v。在URL中正确的版本字符串类型应该是"v0.x.y"

### 相关 issue

Related to #176 

### 这个PR做了什么

添加了前缀变量version_prefix，并添加了如果版本号形似0.x.y，则在构造URL的时候添加version_prefix前缀

---

## 注意

此bash安装器没有经过充分的黑盒测试，可能在不同的版本/系统上还存在问题，并且如果版本号` < 0.1.4`，正则表达式`0\.([1-9])\.([0-9]`仍可检测通过，此处是否需要fix？

---

## 测试

我在本地提取了此段改动代码进行简单测试，并成功通过。

---
