### PR TITLE
fix config error in `uv.toml`

### DIFF
--- a/src/recipe/lang/Python/uv.c
+++ b/src/recipe/lang/Python/uv.c
@@ -2,9 +2,9 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  * -------------------------------------------------------------
  * File Authors  : happy game <happygame1024@gmail.com>
- * Contributors  :  Nul None  <nul@none.org>
+ * Contributors  : ccy <icuichengyi@gmail.com>
  * Created On    : <2024-12-11>
- * Last Modified : <2024-12-11>
+ * Last Modified : <2025-04-02>
  * ------------------------------------------------------------*/
 
 
@@ -81,13 +81,18 @@ pl_python_uv_setsrc (char *option)
 
   // sed -i '/^\[\[index\]\]$/,/^default = true$/{s|^url = ".*"$|url = " source.url "|}' uv_config
   // 将 [[index]] 到 default = true 之间的 url = ".*" 替换为 url = "source.url"
-  char *update_source_cmd = xy_strjoin (5, "sed -i ",
+#if xy_on_macos
+  char *sed_cmd = "sed -i '' ";
+#else
+  char *sed_cmd = "sed -i ";
+#endif
+
+  char *update_source_cmd = xy_strjoin (5, sed_cmd,
                             "'/^\\[\\[index\\]\\]$/,/^default = true$/{s|^url = \".*\"$|url = \"",
                             source.url,
-                            "\"|}' ",
+                            "\"|;}' ",
                             uv_config);
-
-  char *append_source_cmd = xy_strjoin (4, "echo -e '", source_content, "' >> ", uv_config);
+  char *append_source_cmd = xy_strjoin (4, "printf '", source_content, "' >> ", uv_config);
 
   // grep -q '^[[index]]$' uv_config && update_source_cmd || append_source_cmd
   // 如果 uv_config 中存在 [[index]] 则更新, 否则追加到文件末尾


### PR DESCRIPTION
## 描述

### 问题的背景

当前 `chsrc set uv` 命令存在两个问题

- 当 uv.toml 不存在时，`chsrc set uv` 向该文件写入了错误的内容

```toml
# chsrc set uv tuna
-e [[index]]
url = "https://pypi.tuna.tsinghua.edu.cn/simple"
default = true
```

- 当 uv.toml 存在时，由于命令执行错误导致 `chsrc set uv` 本意修改 [[index]] 当前的 url，实际上会添加了一个新的 [[index]]

```toml
# chsrc set uv tuna
-e [[index]]
url = "https://pypi.tuna.tsinghua.edu.cn/simple"
default = true

# chsrc set uv pku
-e [[index]]
url = "https://mirrors.pku.edu.cn/pypi/web/simple"
default = true
```

### 相关 issue

N/A

### 这个PR做了什么

修复了上述两个问题，在更新 ~/.config/uv/uv.toml 时避免错误写 or 重复写

## 方案

## 实现

- 使用 `printf` 命令代替 `echo -e` 避免向文件中写入 '-e'
- 修改错误的 `sed` 命令避免向文件中写入冗余的 '[[index]]'

## 测试

- 运行 `chsrc set uv xxx` 验证 uv.toml 是否正确更新