### PR TITLE
remove useless error messages when `uv` is set but no config file exists

### DIFF
--- a/src/chsrc-main.c
+++ b/src/chsrc-main.c
@@ -23,6 +23,7 @@
  *                 |    juzeon      <skyjuzheng@gmail.com>
  *                 |  Jialin Lyu    <jialinlvcn@aliyun.com>
  *                 | GitHub Copilot <https://github.com/copilot>
+ *                 |     ccy        <icuichengyi@gmail.com>
  *                 |
  * Created On      : <2023-08-28>
  * Last Modified   : <2025-03-25>

--- a/src/recipe/lang/Python/uv.c
+++ b/src/recipe/lang/Python/uv.c
@@ -95,20 +95,23 @@ pl_python_uv_setsrc (char *option)
   char *append_source_cmd = xy_strjoin (4, "printf '", source_content, "' >> ", uv_config);
 
   char *cmd = NULL;
-  if (!xy_file_exist(uv_config)) {
-    // uv_config 不存在，追加到新文件末尾
-    // run: append_source_cmd
-    cmd = append_source_cmd;
-  } else {
-    // uv_config 存在，如果存在 [[index]] 则更新，否则追加到文件末尾
-    // run: grep -q '^[[index]]$' uv_config && update_source_cmd || append_source_cmd
-    cmd = xy_strjoin (6, "grep -q '^\\[\\[index\\]\\]$' ",
-                         uv_config,
-                         " && ",
-                         update_source_cmd,
-                         " || ",
-                         append_source_cmd);
-  }
+  if (!xy_file_exist (uv_config))
+    {
+      // uv_config 不存在，追加到新文件末尾
+      // run: append_source_cmd
+      cmd = append_source_cmd;
+    }
+  else
+    {
+      // uv_config 存在，如果存在 [[index]] 则更新，否则追加到文件末尾
+      // run: grep -q '^[[index]]$' uv_config && update_source_cmd || append_source_cmd
+      cmd = xy_strjoin (6, "grep -q '^\\[\\[index\\]\\]$' ",
+                           uv_config,
+                           " && ",
+                           update_source_cmd,
+                           " || ",
+                           append_source_cmd);
+    }
 
   chsrc_run (cmd, RunOpt_Default);
 

--- a/src/recipe/lang/Python/uv.c
+++ b/src/recipe/lang/Python/uv.c
@@ -94,15 +94,21 @@ pl_python_uv_setsrc (char *option)
                             uv_config);
   char *append_source_cmd = xy_strjoin (4, "printf '", source_content, "' >> ", uv_config);
 
-  // grep -q '^[[index]]$' uv_config && update_source_cmd || append_source_cmd
-  // 如果 uv_config 中存在 [[index]] 则更新, 否则追加到文件末尾
-  // 文件不存在也是追加到新文件末尾
-  char *cmd = xy_strjoin (6, "grep -q '^\\[\\[index\\]\\]$' ",
-                             uv_config,
-                             " && ",
-                             update_source_cmd,
-                             " || ",
-                             append_source_cmd);
+  char *cmd = NULL;
+  if (!xy_file_exist(uv_config)) {
+    // uv_config 不存在，追加到新文件末尾
+    // run: append_source_cmd
+    cmd = append_source_cmd;
+  } else {
+    // uv_config 存在，如果存在 [[index]] 则更新，否则追加到文件末尾
+    // run: grep -q '^[[index]]$' uv_config && update_source_cmd || append_source_cmd
+    cmd = xy_strjoin (6, "grep -q '^\\[\\[index\\]\\]$' ",
+                         uv_config,
+                         " && ",
+                         update_source_cmd,
+                         " || ",
+                         append_source_cmd);
+  }
 
   chsrc_run (cmd, RunOpt_Default);
 


### PR DESCRIPTION
## 描述

### 问题的背景

当不存在 `uv.toml` 时，执行 `chsrc set uv xxx` 可以成功进行换源但是会报错：`grep: /path/to/uv.toml: No such file or directory`

### 相关 issue

#188 

### 这个PR做了什么

修复了 `uv.toml` 不存在时输出不必要的错误提示的问题

## 方案

- 当 `uv.toml` 不存在时直接写入新文件
- 当 `uv.toml` 存在时执行原有逻辑：如果 [[index]] 不存在则追加，否则替换 url

## 测试

运行以下示例不会输出 `No such file or directory`

```sh
rm /path/to/uv.toml
chsrc set uv xxx
```

