### PR TITLE
Update Flutter recipe

### DIFF
--- a/src/chsrc-main.c
+++ b/src/chsrc-main.c
@@ -24,9 +24,10 @@
  *                 |  Jialin Lyu    <jialinlvcn@aliyun.com>
  *                 | GitHub Copilot <https://github.com/copilot>
  *                 |     ccy        <icuichengyi@gmail.com>
+ *                 |  MadDogOwner   <xiaoran@xrgzs.top>
  *                 |
  * Created On      : <2023-08-28>
- * Last Modified   : <2025-04-13>
+ * Last Modified   : <2025-04-15>
  *
  * chsrc: Change Source —— 全平台通用命令行换源工具
  * ------------------------------------------------------------*/

--- a/src/chsrc-main.c
+++ b/src/chsrc-main.c
@@ -66,6 +66,7 @@
   #include "recipe/lang/Rust/rustup.c"
   #include "recipe/lang/Rust/Cargo.c"
 
+#include "recipe/lang/Dart/common.h"
 #include "recipe/lang/Dart/Pub.c"
 #include "recipe/lang/Dart/Flutter.c"
 

--- a/src/recipe/lang/Dart/Flutter.c
+++ b/src/recipe/lang/Dart/Flutter.c
@@ -13,14 +13,21 @@
  * ------------------------------------------------------------*/
 
 /**
- * @update 2024-10-31
+ * @update 2025-04-15
  */
+static SourceProvider_t pl_dart_flutter_upstream =
+{
+  def_upstream, "https://storage.googleapis.com",
+  {NotSkip, NA, NA, "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_v1.0.0-stable.tar.xz"} // 231 MB
+};
+
 static Source_t pl_dart_flutter_sources[] =
 {
-  {&UpstreamProvider, "https://storage.googleapis.com"},
-  {&Sjtug_Zhiyuan,    "https://mirror.sjtu.edu.cn"}, // 没有后缀，怀疑是否存在问题
-  {&Tuna,             "https://mirrors.tuna.tsinghua.edu.cn/git/flutter"}, // URL 带 git
-  {&Nju,              "https://mirror.nju.edu.cn/flutter"}
+  {&pl_dart_flutter_upstream, "https://storage.googleapis.com"},
+  {&FlutterCN,                "https://storage.flutter-io.cn"},
+  {&Sjtug_Zhiyuan,            "https://mirror.sjtu.edu.cn"}, // 没有后缀，怀疑是否存在问题
+  {&Tuna,                     "https://mirrors.tuna.tsinghua.edu.cn/flutter"},
+  {&Nju,                      "https://mirror.nju.edu.cn/flutter"}
 };
 def_sources_n(pl_dart_flutter);
 

--- a/src/recipe/lang/Dart/Flutter.c
+++ b/src/recipe/lang/Dart/Flutter.c
@@ -3,10 +3,10 @@
  * -------------------------------------------------------------
  * File Authors   : Aoran Zeng <ccmywish@qq.com>
  * Contributors   :    czyt    <czyt.go@gmail.com>
- *                |
+  *                |
  * Created On     : <2023-09-10>
  * Major Revision :      2
- * Last Modified  : <2024-11-22>
+ * Last Modified  : <2025-04-15>
  *
  * 2024-09-14: 不得不将Dart和Flutter拆分为两个Target，
  *             因为3家教育网镜像站给出的 Dart 和 Flutter 换源URL模式都不一样
@@ -57,16 +57,11 @@ pl_dart_flutter_setsrc (char *option)
   chsrc_yield_source_and_confirm (pl_dart_flutter);
 
   char *w = NULL;
-
+  char *cmd = NULL;
   if (xy_on_windows)
     {
-      w = xy_strjoin (3, "$env:FLUTTER_STORAGE_BASE_URL = \"", source.url, "\"\n");
-
-      if (xy_file_exist (xy_win_powershell_profile))
-        chsrc_append_to_file (w, xy_win_powershell_profile);
-
-      if (xy_file_exist (xy_win_powershellv5_profile))
-        chsrc_append_to_file (w, xy_win_powershellv5_profile);
+      cmd = xy_strjoin (3, "setx FLUTTER_STORAGE_BASE_URL \"", source.url, "\"");
+      chsrc_run (cmd, RunOpt_No_Last_New_Line);
     }
   else
     {

--- a/src/recipe/lang/Dart/Flutter.c
+++ b/src/recipe/lang/Dart/Flutter.c
@@ -1,9 +1,10 @@
 /** ------------------------------------------------------------
  * SPDX-License-Identifier: GPL-3.0-or-later
  * -------------------------------------------------------------
- * File Authors   : Aoran Zeng <ccmywish@qq.com>
- * Contributors   :    czyt    <czyt.go@gmail.com>
-  *                |
+ * File Authors   : Aoran Zeng  <ccmywish@qq.com>
+ * Contributors   :    czyt     <czyt.go@gmail.com>
+ *                | MadDogOwner <xiaoran@xrgzs.top>
+ *                |
  * Created On     : <2023-09-10>
  * Major Revision :      2
  * Last Modified  : <2025-04-15>

--- a/src/recipe/lang/Dart/Pub.c
+++ b/src/recipe/lang/Dart/Pub.c
@@ -1,9 +1,10 @@
 /** ------------------------------------------------------------
  * SPDX-License-Identifier: GPL-3.0-or-later
  * -------------------------------------------------------------
- * File Authors   : Aoran Zeng <ccmywish@qq.com>
- * Contributors   :    czyt    <czyt.go@gmail.com>
-  *                |
+ * File Authors   : Aoran Zeng  <ccmywish@qq.com>
+ * Contributors   :    czyt     <czyt.go@gmail.com>
+ *                | MadDogOwner <xiaoran@xrgzs.top>
+ *                |
  * Created On     : <2023-09-10>
  * Major Revision :      3
  * Last Modified  : <2025-04-15>

--- a/src/recipe/lang/Dart/Pub.c
+++ b/src/recipe/lang/Dart/Pub.c
@@ -3,10 +3,10 @@
  * -------------------------------------------------------------
  * File Authors   : Aoran Zeng <ccmywish@qq.com>
  * Contributors   :    czyt    <czyt.go@gmail.com>
- *                |
+  *                |
  * Created On     : <2023-09-10>
  * Major Revision :      3
- * Last Modified  : <2024-10-31>
+ * Last Modified  : <2025-04-15>
  *
  * Dart Pub 软件仓库
  * ------------------------------------------------------------*/
@@ -52,16 +52,11 @@ pl_dart_setsrc (char *option)
   chsrc_yield_source_and_confirm (pl_dart);
 
   char *w = NULL;
-
+  char *cmd = NULL;
   if (xy_on_windows)
     {
-      w = xy_strjoin (3, "$env:PUB_HOSTED_URL = \"", source.url, "\"\n");
-
-      if (xy_file_exist (xy_win_powershell_profile))
-        chsrc_append_to_file (w, xy_win_powershell_profile);
-
-      if (xy_file_exist (xy_win_powershellv5_profile))
-        chsrc_append_to_file (w, xy_win_powershellv5_profile);
+      cmd = xy_strjoin (3, "setx PUB_HOSTED_URL \"", source.url, "\"");
+      chsrc_run (cmd, RunOpt_No_Last_New_Line);
     }
   else
     {

--- a/src/recipe/lang/Dart/Pub.c
+++ b/src/recipe/lang/Dart/Pub.c
@@ -12,11 +12,18 @@
  * ------------------------------------------------------------*/
 
 /**
- * @update 2024-10-31
+ * @update 2025-04-15
  */
+ static SourceProvider_t pl_dart_upstream =
+{
+  def_upstream, "https://pub.dev",
+  {NotSkip, NA, NA, "https://pub.dev/packages/flutter_vision/versions/1.1.4.tar.gz"} // 37.05 MB
+};
+
 static Source_t pl_dart_sources[] =
 {
-  {&UpstreamProvider, "https://pub.dev"},
+  {&pl_dart_upstream, "https://pub.dev"},
+  {&FlutterCN,        "https://pub.flutter-io.cn"},
   {&Sjtug_Zhiyuan,    "https://mirror.sjtu.edu.cn/dart-pub"},
   {&Tuna,             "https://mirrors.tuna.tsinghua.edu.cn/dart-pub"},
   {&Nju,              "https://mirror.nju.edu.cn/dart-pub"}

--- a/src/recipe/lang/Dart/common.h
+++ b/src/recipe/lang/Dart/common.h
@@ -1,9 +1,9 @@
 /** ------------------------------------------------------------
  * SPDX-License-Identifier: GPL-3.0-or-later
  * -------------------------------------------------------------
- * File Authors   : Aoran Zeng <ccmywish@qq.com>
- * Contributors   :    czyt    <czyt.go@gmail.com>
-  *                |
+ * File Authors   : MadDogOwner <xiaoran@xrgzs.top>
+ * Contributors   :  Nil Null   <nil@null.org>
+ *                |
  * Created On     : <2025-04-15>
  * Major Revision :      1
  * Last Modified  : <2025-04-15>

--- a/src/recipe/lang/Dart/common.h
+++ b/src/recipe/lang/Dart/common.h
@@ -11,6 +11,6 @@
 
 static MirrorSite_t FlutterCN =
 {
-  "cfug", "CFUG", "China Flutter User Group", "https://flutter.cn/",
+  "cfug", "CFUG", "Flutter 社区", "https://flutter.cn/",
   {NotSkip, NA, NA, "https://storage.flutter-io.cn/flutter_infra_release/releases/stable/linux/flutter_linux_v1.0.0-stable.tar.xz"} // 231 MB
 };

--- a/src/recipe/lang/Dart/common.h
+++ b/src/recipe/lang/Dart/common.h
@@ -1,0 +1,16 @@
+/** ------------------------------------------------------------
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * -------------------------------------------------------------
+ * File Authors   : Aoran Zeng <ccmywish@qq.com>
+ * Contributors   :    czyt    <czyt.go@gmail.com>
+  *                |
+ * Created On     : <2025-04-15>
+ * Major Revision :      1
+ * Last Modified  : <2025-04-15>
+ * ------------------------------------------------------------*/
+
+static MirrorSite_t FlutterCN =
+{
+  "cfug", "CFUG", "China Flutter User Group", "https://flutter.cn/",
+  {NotSkip, NA, NA, "https://storage.flutter-io.cn/flutter_infra_release/releases/stable/linux/flutter_linux_v1.0.0-stable.tar.xz"} // 231 MB
+};

--- a/src/recipe/menu.c
+++ b/src/recipe/menu.c
@@ -167,7 +167,7 @@ available_mirrors[] = {
   &Api7, &Fit2Cloud, &DaoCloud,
 
   /* 专用镜像站 */
-  &RubyChina, &EmacsChina, &NpmMirror, &GoProxyIO, &GoProxyCN, &RsProxyCN,
+  &RubyChina, &EmacsChina, &NpmMirror, &GoProxyIO, &GoProxyCN, &RsProxyCN, &FlutterCN,
 
   // 暂不支持 &NugetOrg
   // 不要列出 &UpstreamProvider 和 &UserDefinedProvider


### PR DESCRIPTION
## 描述

### 问题的背景

- Windows 下 Flutter 换源方法错误

### 相关 issue

- Closes https://github.com/RubyMetric/chsrc/issues/192

### 这个PR做了什么

- 使用 `setx` 命令设置用户变量
- 增加 CUFG (China Flutter User Group)
- 增加 默认源测速

---

## 方案

- 使用 `setx` 命令设置用户变量

---

## 实现

- 使用 `setx` 命令设置用户变量
- 增加 CUFG (China Flutter User Group)
- 增加 默认源测速

---

## 注意

- 不太懂 C 和本项目的协作流程，如果有问题请多多指教

---

## 测试

```powershell
D:\temp\chsrc [flutter ≡]> ucrt64 -c "make CC=gcc"

Compile done using 'gcc' -Iinclude -Ilib
D:\temp\chsrc [flutter ≡]> clang64 -c "make CC=clang"

Compile done using 'clang' -Iinclude -Ilib -target x86_64-pc-windows-gnu
D:\temp\chsrc [flutter ≡]> .\chsrc.exe set flutter
[chsrc 测速] 测速中

  ^ 上游默认源 (https://storage.googleapis.com) ... 23.26 MByte/s
  - China Flutter User Group ... 12.14 MByte/s
  - 上海交通大学致远镜像站 ... 46.73 MByte/s
  - 清华大学开源软件镜像站 ... 42.01 MByte/s
  - 南京大学开源镜像站 ... 12.90 MByte/s

最快镜像站: 上海交通大学致远镜像站
选中镜像站: SJTUG-zhiyuan (sjtu)
--------------------------------
[chsrc 运行] setx FLUTTER_STORAGE_BASE_URL "https://mirror.sjtu.edu.cn"

SUCCESS: Specified value was saved.
[chsrc 运行] ✓ 命令执行成功
--------------------------------
chsrc: 全自动换源完成, 感谢镜像提供方: 上海交通大学致远镜像站
```

---
