### PR TITLE
Re-add `cqu` mirror

### DIFF
--- a/src/framework/mirror.c
+++ b/src/framework/mirror.c
@@ -8,7 +8,7 @@
  *               |  Jialin Lyu   <jialinlvcn@aliyun.com>
  *               |
  * Created On    : <2023-08-29>
- * Last Modified : <2025-05-27>
+ * Last Modified : <2025-06-17>
  *
  * 通用镜像站
  * ------------------------------------------------------------*/
@@ -150,20 +150,16 @@ Nju =
 {
   "nju", "NJU", "南京大学开源镜像站", "https://mirrors.nju.edu.cn/",
   {NotSkip, NA, NA, "https://mirrors.nju.edu.cn/archlinux" Big_File_archlinux}
-};
+},
 
 /**
- * @note 2023-09-05 只使用了不到5次，重庆大学镜像站就把我的ip封杀了，对用户来说封杀策略过严，暂时不可靠，暂时不用
- *
- * Cqu =
- * {
- *   "cqu", "CQU", "重庆大学开源软件镜像站", "https://mirrors.cqu.edu.cn/",
- *   {NotSkip, NA, NA, "https://mirrors.cqu.edu.cn/speedtest/1000mb.bin"}
- * };
- *
- */
-
-
+ * @note 2023-09-05 封杀策略过严，谨慎使用
+ **/
+Cqu =
+{
+  "cqu", "CQU", "重庆大学开源软件镜像站", "https://mirrors.cqu.edu.cn/",
+  {NotSkip, NA, NA, "https://mirrors.cqu.edu.cn/ubuntu-releases" Big_File_ubuntu}
+};
 
 /**
  * 商业公司提供的源

--- a/src/recipe/lang/Rust/Cargo.c
+++ b/src/recipe/lang/Rust/Cargo.c
@@ -5,7 +5,7 @@
  * Contributors  :  Nil Null  <nil@null.org>
  *               |
  * Created On    : <2023-08-30>
- * Last Modified : <2024-12-18>
+ * Last Modified : <2025-06-17>
  * ------------------------------------------------------------*/
 
 static SourceProvider_t pl_rust_cargo_upstream =

--- a/src/recipe/menu.c
+++ b/src/recipe/menu.c
@@ -6,7 +6,7 @@
  *                |
  * Created On     : <2023-09-01>
  * Major Revision :      1
- * Last Modified  : <2025-05-27>
+ * Last Modified  : <2025-06-17>
  * ------------------------------------------------------------*/
 
 /* Begin Target Matrix */
@@ -151,10 +151,7 @@ available_mirrors[] = {
   &Hust, &Iscas, &Scau,
   &Nyist, &Sdu,  &Cqupt,
 
-  &Nju,
-
-  /* 已支持但未启用 */
-  // &Cqu,
+  &Nju, &Cqu,
 
 
 


### PR DESCRIPTION
## 描述

### 问题背景

重新启用 CQU 镜像站

在开发的时候由于 CQU 封杀策略过严（5次便封杀IP），所以出于保护用户体验的问题，我没有启用它，并且后续我们和其某位管理员有一次不愉快的经历。

但是此PR由用户提出，尊重用户的需求和体验，我们也不必再计较以往的事情。

- Relates #209

<br>



## 方案

重新启用

<br>
