### PR TITLE
add speed test link for cargo

### DIFF
--- a/src/recipe/lang/Rust/Cargo.c
+++ b/src/recipe/lang/Rust/Cargo.c
@@ -11,19 +11,20 @@
 static SourceProvider_t pl_rust_cargo_upstream =
 {
   def_upstream, "https://crates.io/",
-  def_need_measure_info
+  {NotSkip, NA, NA, "https://crates.io/api/v1/crates/windows/0.58.0/download"}
 };
 
 /**
  * @update 2025-06-17
  * @note 以下都支持稀疏索引，我们换源时都将默认添加 `sparse+`
  * @note 链接末尾的 `/` 不能缺少
+ * @note 经验证，南大的镜像同步失败，实际情况下多数packages不可用
+ * @note 经验证，华中科大的镜像同步部分失败，较多常见packages不可用
  */
 static Source_t pl_rust_cargo_sources[] =
 {
   {&pl_rust_cargo_upstream,  "https://github.com/rust-lang/crates.io-index/"},
   {&MirrorZ,       "https://mirrors.cernet.edu.cn/crates.io-index/"},
-  {&Nju,           "https://mirror.nju.edu.cn/git/crates.io-index.git/"},
   {&Zju,           "https://mirrors.zju.edu.cn/crates.io-index/"},
   {&Sjtug_Zhiyuan, "https://mirrors.sjtug.sjtu.edu.cn/crates.io-index/"},
   {&Tuna,          "https://mirrors.tuna.tsinghua.edu.cn/crates.io-index/"},
@@ -31,7 +32,6 @@ static Source_t pl_rust_cargo_sources[] =
   {&Ustc,          "https://mirrors.ustc.edu.cn/crates.io-index/"},
   {&RsProxyCN,     "https://rsproxy.cn/index/"},
   {&Ali,           "https://mirrors.aliyun.com/crates.io-index/"},
-  {&Hust,          "https://mirrors.hust.edu.cn/crates.io-index/"},
   {&Cqu,           "https://mirrors.cqu.edu.cn/crates.io-index/"}
 };
 def_sources_n(pl_rust_cargo);

--- a/src/recipe/lang/Rust/common.h
+++ b/src/recipe/lang/Rust/common.h
@@ -10,5 +10,17 @@
 static MirrorSite_t RsProxyCN =
 {
   "rsproxycn", "RsProxy.cn", "字节跳动基础架构Dev Infra", "https://rsproxy.cn/",
-  {SKIP, ToFill, ToFill, NULL}
+  {NotSkip, NA, NA, "https://rsproxy.cn/api/v1/crates/windows/0.58.0/download"}
+},
+Ali =
+{
+    "ali", "Ali OPSX Public", "阿里巴巴开源镜像站(公网)", "https://developer.aliyun.com/mirror/",
+    {NotSkip, NA, NA, "https://mirrors.aliyun.com/crates/api/v1/crates/windows/0.58.0/download"}
 };
+
+static MirrorSite_t Ustc =
+{
+    "ustc", "USTC", "中国科学技术大学开源镜像站", "https://mirrors.ustc.edu.cn/",
+    {NotSkip, NA, NA, "https://crates-io.proxy.ustclug.org/api/v1/crates/windows/0.58.0/download"}
+};
+


### PR DESCRIPTION
## 描述

### 问题背景 (必填)

1. 增加了cargo的测速链接
2. 禁用了华中科技大学和南大的链接，因其存在较多packages的缺失（就当是测试环节的修改，不另开pr了）

## 方案 (必填)

1. 增加链接
2. 依次验证后酌情删除与禁用

## 备注 (可选)

@chenrui333 由于我本人对C实在不了解，我不知道该怎么重新定义（或者直接在 [`cargo.c` 的 L22 处](https://github.com/RubyMetric/chsrc/blob/73c63d117f3fe5bb3740b04848d2a133328e3fe7/src/recipe/lang/Rust/Cargo.c#L22)进行修改 ）相关镜像针对cargo的测速链接，现在程序因为多次定义而无法运行了（本想覆盖原始定义的，但是不会……）

