### PR TITLE
add tlmgr speed test url

### DIFF
--- a/src/recipe/ware/TeX-Live.c
+++ b/src/recipe/ware/TeX-Live.c
@@ -13,17 +13,16 @@
  * @update 2025-07-13
  */
 static Source_t wr_tex_sources[] =
-{
-  {&UpstreamProvider,  NULL, NULL},
-  {&MirrorZ,          "https://mirrors.cernet.edu.cn/CTAN/systems/texlive/tlnet", NULL},
-  {&Sjtug_Zhiyuan,    "https://mirrors.sjtug.sjtu.edu.cn/ctan/systems/texlive/tlnet", NULL},
-  {&Tuna,             "https://mirrors.tuna.tsinghua.edu.cn/CTAN/systems/texlive/tlnet", NULL},
-  {&Bfsu,             "https://mirrors.bfsu.edu.cn/CTAN/systems/texlive/tlnet", NULL},
-  {&Bjtu,             "https://mirror.bjtu.edu.cn/ctan/systems/texlive/tlnet", NULL},
-  {&Lzuoss,           "https://mirror.lzu.edu.cn/CTAN/systems/texlive/tlnet", NULL},
-  {&Jlu,              "https://mirrors.jlu.edu.cn/CTAN/systems/texlive/tlnet", NULL},
-  {&Sustech,          "https://mirrors.sustech.edu.cn/CTAN/systems/texlive/tlnet", NULL}
-};
+    {
+        {&UpstreamProvider, NULL, NULL},
+        {&MirrorZ, "https://mirrors.cernet.edu.cn/CTAN/systems/texlive/tlnet", NULL},
+        {&Sjtug_Zhiyuan, "https://mirrors.sjtug.sjtu.edu.cn/ctan/systems/texlive/tlnet", "https://mirrors.sustech.edu.cn/CTAN/systems/texlive/tlnet/archive/fandol.tar.xz"},
+        {&Tuna, "https://mirrors.tuna.tsinghua.edu.cn/CTAN/systems/texlive/tlnet", "https://mirrors.tuna.tsinghua.edu.cn/CTAN/systems/texlive/tlnet/archive/fandol.tar.xz"},
+        {&Bfsu, "https://mirrors.bfsu.edu.cn/CTAN/systems/texlive/tlnet", "https://mirrors.bfsu.edu.cn/CTAN/systems/texlive/tlnet/archive/fandol.tar.xz"},
+        {&Bjtu, "https://mirror.bjtu.edu.cn/ctan/systems/texlive/tlnet", "https://mirror.bjtu.edu.cn/ctan/systems/texlive/tlnet/archive/fandol.tar.xz"},
+        {&Lzuoss, "https://mirror.lzu.edu.cn/CTAN/systems/texlive/tlnet", "https://mirror.lzu.edu.cn/CTAN/systems/texlive/tlnet/archive/fandol.tar.xz"},
+        {&Jlu, "https://mirrors.jlu.edu.cn/CTAN/systems/texlive/tlnet", "https://mirrors.jlu.edu.cn/CTAN/systems/texlive/tlnet/archive/fandol.tar.xz"},
+        {&Sustech, "https://mirrors.sustech.edu.cn/CTAN/systems/texlive/tlnet", "https://mirrors.sustech.edu.cn/CTAN/systems/texlive/tlnet/archive/fandol.tar.xz"}};
 def_sources_n(wr_tex);
 
 


### PR DESCRIPTION
## 问题描述

1. 尝试性地增加了tlmgr各镜像站的测速链接
2. `N/A`

<br>



## 方案与实现

选取了一个20M的package作为测速目标，手动下载测试无误
