### PR TITLE
reset settings to avoid auto-format

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,21 @@
 {
-    "C_Cpp.intelliSenseEngine": "Tag Parser",
+    "C_Cpp.clang_format_fallbackStyle": "none",
     "C_Cpp.default.browse.limitSymbolsToIncludedHeaders": false,
-    "editor.formatOnSave": false,
-    "vscode-just.formatOnSave": false,
-    "[yaml]": {
-        "editor.defaultFormatter": "redhat.vscode-yaml"
+    "C_Cpp.formatting": "disabled",
+    "C_Cpp.intelliSenseEngine": "Tag Parser",
+    "[c]": {
+        "editor.defaultFormatter": null
+    },
+    "[h]": {
+        "editor.defaultFormatter": null
     },
     "[jsonc]": {
         "editor.defaultFormatter": "vscode.json-language-features"
-    }
+    },
+    "[yaml]": {
+        "editor.defaultFormatter": "redhat.vscode-yaml"
+    },
+    "editor.formatOnSave": false,
+    "editor.tabSize": 2,
+    "vscode-just.formatOnSave": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,8 @@
     "C_Cpp.formatting": "disabled",
     "C_Cpp.intelliSenseEngine": "Tag Parser",
     "[c]": {
-        "editor.defaultFormatter": null
+        "editor.defaultFormatter": null,
+        "editor.tabSize": 2
     },
     "[h]": {
         "editor.defaultFormatter": null
@@ -16,6 +17,5 @@
         "editor.defaultFormatter": "redhat.vscode-yaml"
     },
     "editor.formatOnSave": false,
-    "editor.tabSize": 2,
     "vscode-just.formatOnSave": false
 }


### PR DESCRIPTION
## 问题描述

1. 原来的设置没搞好，在我的设备上还是会自动format，所以打了个补丁，现在应该可以适用于全部设备了
2. `N/A`

## 方案与实现

1. 增加了几种格式的format禁止设置
2. 重新排序了一下，现在观感好多了
3. 硬设置了tab为2（与现有文件一致）