### PR TITLE
修复获取父目录和标准化路径错误的问题

### DIFF
--- a/lib/xy.h
+++ b/lib/xy.h
@@ -927,32 +927,31 @@ xy_normalize_path (const char *path)
     return new;
 }
 
+/**
+ * @note 总是返回不含末尾斜杠的父目录路径
+ */
 static char *
 xy_parent_dir (const char *path)
 {
   char *dir = xy_normalize_path (path);
+  dir = xy_str_gsub (dir, "\\", "/");
+  if (xy_str_end_with (dir, "/"))
+    dir = xy_str_delete_suffix (dir, "/");
+
   char *last = NULL;
+
+  last = strrchr (dir, '/');
+  if (!last)
+    {
+      /* current dir */
+      return ".";
+    }
+  *last = '\0';
+
   if (xy_on_windows)
-    {
-      last = strrchr (dir, '\\');
-      if (!last)
-        {
-          /* current dir */
-          return ".";
-        }
-      *last = '\0';
-    }
+    return xy_str_gsub (dir, "/", "\\");
   else
-    {
-      last = strrchr (dir, '/');
-      if (!last)
-        {
-          /* current dir */
-          return ".";
-        }
-      *last = '\0';
-    }
-  return dir;
+    return dir;
 }
 
 #endif

--- a/lib/xy.h
+++ b/lib/xy.h
@@ -912,26 +912,19 @@ xy_normalize_path (const char *path)
 {
   char *new = xy_str_strip (path); // 防止开发者多写了空白符
 
-  if (xy_on_windows)
+  if (xy_str_start_with (new, "~"))
     {
-      if (xy_str_start_with (new, "~/"))
-        {
-          // 或 %USERPROFILE%
-          new = xy_strjoin (3, xy_os_home, "\\",
-                            xy_str_delete_prefix (new, "~/"));
-        }
-      new = xy_str_gsub (new, "/", "\\");
-    }
-  else
-    {
-      if (xy_str_start_with (new, "~/"))
-        {
-          new = xy_strjoin (3, xy_os_home, "/",
-                            xy_str_delete_prefix (new, "~/"));
-        }
+      new = xy_strjoin (3, xy_os_home, "/",
+                           xy_str_delete_prefix (new, "~"));
     }
 
-  return new;
+  new = xy_str_gsub (new, "\\", "/");
+  new = xy_str_gsub (new, "//", "/");
+
+  if (xy_on_windows)
+    return xy_str_gsub (new, "/", "\\");
+  else
+    return new;
 }
 
 static char *

--- a/test/xy.c
+++ b/test/xy.c
@@ -103,6 +103,13 @@ main (int argc, char const *argv[])
       assert (xy_file_exist (xy_win_powershell_profile));
       assert (true == xy_file_exist (xy_win_powershellv5_profile));
       assert (xy_dir_exist ("C:\\Users"));
+      assert_str (xy_normalize_path ("C:\\a bc\\def\\"), "C:\\a bc\\def\\");
+      assert_str (xy_normalize_path ("a/b c/d"), "a\\b c\\d");
+      assert_str (xy_normalize_path ("a/b c/d/"), "a\\b c\\d\\");
+      assert_str (xy_parent_dir ("a/b c/d"), "a\\b c");
+      assert_str (xy_parent_dir ("a/b c\\d/"), "a\\b c");
+      assert_str (xy_parent_dir (xy_normalize_path ("~/")), "C:\\Users");
+      assert_str (xy_parent_dir (xy_normalize_path ("~")), "C:\\Users");
     }
   else
     {
@@ -115,6 +122,8 @@ main (int argc, char const *argv[])
           assert (xy_file_exist (xy_bashrc));
         }
       assert (xy_dir_exist ("/etc"));
+      assert_str (xy_normalize_path ("a\\b c\\d"), "a/b c/d");
+      assert_str (xy_normalize_path ("a\\b c\\d\\"), "a/b c/d/");
     }
 
   println (xy_normalize_path (" \n ~/haha/test/123 \n\r "));


### PR DESCRIPTION
## 问题描述

1. https://github.com/RubyMetric/chsrc/pull/259#issuecomment-3194298314
2.  `N/A`

<br>



## 方案与实现

1. 这两个函数都直接转换为linux的路径分隔符（`/`）并进行计算， 仅在最后统一转换为适合win/linux的路径分隔符
2. 增加了对单独一个 ~ 的处理
3. 修复了父目录对于以 `\` 结尾的目录处理有误的问题
4. 增加了一堆tests