### PR TITLE
fix(pip): 修复 pip 的 getsrc

### DIFF
--- a/src/recipe/lang/Python/pip.c
+++ b/src/recipe/lang/Python/pip.c
@@ -10,12 +10,12 @@ pl_python_pip_prelude (void)
   chef_prep_this (pl_python_pip, gsr);
 
   chef_set_created_on   (this, "2023-09-03");
-  chef_set_last_updated (this, "2025-07-11");
+  chef_set_last_updated (this, "2025-09-10");
   chef_set_sources_last_updated (this, "2025-07-11");
 
   chef_set_chef (this, NULL);
   chef_set_cooks (this, 1, "@ccmywish");
-  chef_set_sauciers (this, 0);
+  chef_set_sauciers (this, 1, "@happy-game");
 
   chef_allow_local_mode (this, CanNot, NULL, NULL);
   chef_allow_english(this);
@@ -31,8 +31,24 @@ pl_python_pip_getsrc (char *option)
   char *py_prog_name = NULL;
   pl_python_get_py_program_name (&py_prog_name);
 
-  char *cmd = xy_2strcat (py_prog_name, " -m pip config get global.index-url");
-  chsrc_run (cmd, RunOpt_Default);
+  char *cmd = xy_2strcat (py_prog_name, " -m pip config get global.index-url 2>/dev/null");
+  
+  int status = system (cmd);
+  if (0 == status)
+    {
+      // 执行成功时显示当前源
+    }
+  else
+    {
+      // 执行失败时显示默认源
+      if (ENGLISH)
+        chsrc_note2 ("No source configured in pip, showing default upstream source:");
+      else
+        chsrc_note2 ("pip 中未配置源，显示默认上游源：");
+      
+      Source_t default_source = chsrc_yield_source (&pl_python_group_target, "upstream");
+      chsrc_log (default_source.url);
+    }
 }
 
 


### PR DESCRIPTION
## 问题描述

在没有设置过源时 `chsrc get pip`会失败:
```
./chsrc get python
[chsrc 检查] x 命令 poetry 不存在
[chsrc 检查] x 命令 pdm 不存在
[chsrc 检查] x 命令 uv 不存在
[chsrc 检查] ✓ 命令 python3 存在
[chsrc 运行] python3 -m pip config get global.index-url
ERROR: No such key - global.index-url
[chsrc 运行] x 命令执行失败，退出状态: 256
chsrc: 关键错误，强制结束
```
Close: #272
<br>



## 方案与实现

使用  `python -m pip config get global.index-url 2>/dev/null` 获取源，失败时会退至显示默认源(Upstream)

<br>
