### PR TITLE
修复Android系统检测

### DIFF
--- a/lib/xy.h
+++ b/lib/xy.h
@@ -1284,23 +1284,13 @@ xy_detect_os ()
         }
     }
 
-  FILE *fp = fopen ("/proc/version", "r");
-  if (fp)
-    {
-      char buf[256] = {0};
-      fread (buf, 1, sizeof(buf) - 1, fp);
-      fclose (fp);
-      if (strstr (buf, "Android"))
-        {
-          xy.on_android = true;
-          return;
-        }
-      else if (strstr (buf, "Linux"))
-        {
-          xy.on_linux = true;
-          return;
-        }
-    }
+    char *android_env = getenv ("ANDROID_ROOT");
+    if (android_env == "/system")
+      {
+        xy.on_linux = true;
+        xy.on_android = true;
+        return;
+      }
 
   /* 判断 macOS */
   DIR *d = opendir ("/System/Applications");

--- a/lib/xy.h
+++ b/lib/xy.h
@@ -1284,11 +1284,23 @@ xy_detect_os ()
         }
     }
 
-  // REF: https://android.googlesource.com/platform/system/core/+/refs/heads/main/rootdir/init.environ.rc.in
+  FILE *fp = fopen ("/proc/version", "r");
+  if (fp)
+    {
+      char buf[256] = {0};
+      fread (buf, 1, sizeof(buf) - 1, fp);
+      fclose (fp);
+      if (strstr (buf, "Linux"))
+        {
+          xy.on_linux = true;
+          return;
+        }
+    }
+
+  // @consult https://android.googlesource.com/platform/system/core/+/refs/heads/main/rootdir/init.environ.rc.in
   char *android_env = getenv ("ANDROID_ROOT");
   if (xy_str_find (android_env, "/system").found)
     {
-      xy.on_linux = true;
       xy.on_android = true;
       return;
     }
@@ -1303,6 +1315,7 @@ xy_detect_os ()
         {
           xy.on_macos = true;
           closedir (d);
+          return;
         }
     }
 
@@ -1324,6 +1337,7 @@ xy_detect_os ()
       pclose (fp);
       if (strstr (buf, "BSD")  != NULL)
         xy.on_bsd = true;
+        return;
     }
 
   if (!(xy.on_windows || xy.on_linux || xy.on_android || xy.on_macos || xy.on_bsd))

--- a/lib/xy.h
+++ b/lib/xy.h
@@ -1284,13 +1284,14 @@ xy_detect_os ()
         }
     }
 
-    char *android_env = getenv ("ANDROID_ROOT");
-    if (android_env == "/system")
-      {
-        xy.on_linux = true;
-        xy.on_android = true;
-        return;
-      }
+  // REF: https://android.googlesource.com/platform/system/core/+/refs/heads/main/rootdir/init.environ.rc.in
+  char *android_env = getenv ("ANDROID_ROOT");
+  if (xy_str_find (android_env, "/system").found)
+    {
+      xy.on_linux = true;
+      xy.on_android = true;
+      return;
+    }
 
   /* 判断 macOS */
   DIR *d = opendir ("/System/Applications");


### PR DESCRIPTION
## 问题描述

1. 使用了安卓默认的系统环境变量进行检测
2. fix #312 

<br>



## 方案与实现

使用环境变量 `export ANDROID_ROOT /system`

ref:

https://www.herongyang.com/Android/System-Information-System-Environment-Variables.html
https://blog.csdn.net/tkwxty/article/details/106733981
https://android.googlesource.com/platform/system/core/+/refs/heads/main/rootdir/init.environ.rc.in