### PR TITLE
修复 rust cargo 测速链接404的问题

### DIFF
--- a/src/recipe/lang/Rust/Cargo.c
+++ b/src/recipe/lang/Rust/Cargo.c
@@ -2,6 +2,9 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  * ------------------------------------------------------------*/
 
+#define RAWSTR_pl_rust_cargo_default_download_url "https://static.crates.io/crates/windows/windows-0.58.0.crate"
+#define RAWSTR_pl_rust_cargo_custom_default_download_url "api/v1/crates/windows/0.58.0/download"
+
 def_target(pl_rust_cargo, "rust/cargo/crate/crates");
 
 void
@@ -10,8 +13,8 @@ pl_rust_cargo_prelude (void)
   chef_prep_this (pl_rust_cargo, gsr);
 
   chef_set_created_on   (this, "2023-08-30");
-  chef_set_last_updated (this, "2025-12-29");
-  chef_set_sources_last_updated (this, "2025-12-29");
+  chef_set_last_updated (this, "2025-12-30");
+  chef_set_sources_last_updated (this, "2025-12-30");
 
   chef_set_chef (this, NULL);
   chef_set_cooks (this, 2, "@Mikachu2333", "@ccmywish");


### PR DESCRIPTION
## 问题描述

1. 原始api全炸了，重新抓了一次，现在参差不齐的，有部分直接放弃了镜像，还是用的原始链接让用户下载，有的镜像站做了镜像，用户可以通过镜像站下载
2. fix #329 

<br>



## 方案与实现

1. 修正url

## 其它

@ccmywish 现在因为有一部分镜像站偷懒没做实际镜像，只做了个镜像的目录列表导致下载失效。所以现在有一部分镜像站测速链接变成了原始站点的下载链接，能不能在测速阶段对这类奇葩东西做个提示？