### PR TITLE
修复ubuntu arm64下reset的问题

### DIFF
--- a/src/chsrc-main.c
+++ b/src/chsrc-main.c
@@ -75,7 +75,8 @@ chsrc_register_contributors ()
   // 该 ID 为 Gitee ID
   chef_register_contributor ("@hezonglun",      "HeZongLun",      "hezonglun123456@outlook.com",    NULL);
   chef_register_contributor ("@Young-Lord",     "LY",             "ly-niko@qq.com",                 NULL);
-  chef_register_contributor ("@MingriLingran",  "MingriLingran",  "i@linran.moe", NULL);
+  chef_register_contributor ("@MingriLingran",  "MingriLingran",  "i@linran.moe",                   NULL);
+  chef_register_contributor ("@usernameisnull", "MaBing",         "cumt_ttr@163.com",               NULL);
 
   /**
    * AI贡献者：

--- a/src/recipe/os/APT/Ubuntu.c
+++ b/src/recipe/os/APT/Ubuntu.c
@@ -11,12 +11,12 @@ os_ubuntu_prelude ()
   chef_prep_this (os_ubuntu, gsr);
 
   chef_set_created_on   (this, "2023-08-30");
-  chef_set_last_updated (this, "2025-08-10");
-  chef_set_sources_last_updated (this, "2025-07-11");
+  chef_set_last_updated (this, "2026-01-20");
+  chef_set_sources_last_updated (this, "2026-01-20");
 
   chef_set_chef (this, NULL);
   chef_set_cooks (this, 2, "@ccmywish", "@G_I_Y");
-  chef_set_sauciers (this, 1, "@XUANJI233");
+  chef_set_sauciers (this, 2, "@XUANJI233", "@usernameisnull");
 
   chef_allow_local_mode (this, CanNot, NULL, NULL);
   chef_deny_english(this);
@@ -25,8 +25,8 @@ os_ubuntu_prelude ()
   chef_set_note(this, NULL, NULL);
 
   def_sources_begin()
-  {&UpstreamProvider, "http://archive.ubuntu.com/ubuntu/",  FeedByPrelude}, /* 不支持https */
-  {&MirrorZ,          "https://mirrors.cernet.edu.cn/ubuntu/",FeedByPrelude},
+  {&UpstreamProvider, "http://archive.ubuntu.com/ubuntu",  FeedByPrelude}, /* 不支持https */
+  {&MirrorZ,          "https://mirrors.cernet.edu.cn/ubuntu",FeedByPrelude},
   {&Ali,              "https://mirrors.aliyun.com/ubuntu",FeedByPrelude},
   {&Volcengine,       "https://mirrors.volces.com/ubuntu",FeedByPrelude},
   {&Bfsu,             "https://mirrors.bfsu.edu.cn/ubuntu",FeedByPrelude},
@@ -148,5 +148,12 @@ os_ubuntu_setsrc (char *option)
 void
 os_ubuntu_resetsrc (char *option)
 {
+  use_this (os_ubuntu);
+  char *arch = chsrc_get_cpuarch ();
+  if (strncmp (arch, "x86_64", 6)!=0)
+    {
+      // ubuntu arm的源地址和x86_64不一样
+      this->sources[0].url = "http://ports.ubuntu.com/ubuntu";
+    }
   os_ubuntu_setsrc (option);
 }


### PR DESCRIPTION
## 问题描述

相关的issue: https://github.com/RubyMetric/chsrc/issues/334

<br>



## 方案与实现

1. 替换的时候多出的/
2. ubuntu在arm架构下的原始的repo是`http://ports.ubuntu.com/ubuntu-ports/`而不是`http://archive.ubuntu.com/ubuntu-ports` 
```
root@iZ2vc7gy15t4z34gcehj1gZ:~/chsrc# ./chsrc-ci-release reset ubuntu
[chsrc 检查] x 文件 /etc/apt/sources.list.d/ubuntu.sources 不存在
[chsrc 提醒] 将基于旧格式(非DEB822)换源
[chsrc 检查] ✓ 文件 /etc/apt/sources.list 存在
选中镜像站: Upstream (upstream)
--------------------------------
[chsrc 备份] /etc/apt/sources.list -> /etc/apt/sources.list.bak
[chsrc 运行] sed -E -i 's@https?://.*/ubuntu-ports/?@http://archive.ubuntu.com/ubuntu-ports@g' /etc/apt/sources.list
[chsrc 运行] ✓ 命令执行成功

[chsrc 运行] apt update
Ign:1 http://archive.ubuntu.com/ubuntu-ports jammy InRelease
Ign:2 http://archive.ubuntu.com/ubuntu-ports jammy-updates InRelease
Ign:3 http://archive.ubuntu.com/ubuntu-ports jammy-backports InRelease
Ign:4 http://archive.ubuntu.com/ubuntu-ports jammy-security InRelease
Err:5 http://archive.ubuntu.com/ubuntu-ports jammy Release
  404  Not Found [IP: 185.125.190.82 80]
Err:6 http://archive.ubuntu.com/ubuntu-ports jammy-updates Release
  404  Not Found [IP: 185.125.190.82 80]
Err:7 http://archive.ubuntu.com/ubuntu-ports jammy-backports Release
  404  Not Found [IP: 185.125.190.82 80]
Err:8 http://archive.ubuntu.com/ubuntu-ports jammy-security Release
  404  Not Found [IP: 185.125.190.82 80]
Reading package lists... Done
E: The repository 'http://archive.ubuntu.com/ubuntu-ports jammy Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
E: The repository 'http://archive.ubuntu.com/ubuntu-ports jammy-updates Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
E: The repository 'http://archive.ubuntu.com/ubuntu-ports jammy-backports Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
E: The repository 'http://archive.ubuntu.com/ubuntu-ports jammy-security Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
[chsrc 运行] x 命令执行失败，退出状态: 25600
chsrc: 关键错误，强制结束
```

<br>
