### PR TITLE
Remove awk dependency from POSIX installer

### DIFF
--- a/tool/installer.sh
+++ b/tool/installer.sh
@@ -148,13 +148,13 @@ get_arch() {
 }
 
 get_platform() {
-  echo $(uname -s | awk '{print tolower($0)}')
+  uname -s | tr '[:upper:]' '[:lower:]'
 }
 
 # Linux   -> GNU/Linux
 # Android -> Android
 get_os() {
-  echo $(uname -o | awk '{print tolower($0)}')
+  uname -o | tr '[:upper:]' '[:lower:]'
 }
 
 


### PR DESCRIPTION
## 问题

在缺少 `awk` 的环境中，POSIX 安装脚本会在识别平台时失败，导致 `platform` 为空。

即使当前机器本身有可用的预编译二进制文件，安装脚本也会误判为“不支持的平台”，并提示用户使用 `chsrc-bootstrap` 或自行编译。
```bash
$ curl https://chsrc.run/posix | sudo bash
bash: line 149: awk: command not found
[ERROR] 抱歉，暂无预编译二进制文件供你所在的平台:  使用。请使用 chsrc-bootstrap 或 自行编译
```

## 修改

将平台和系统名称的小写转换从 `awk` 改为 `tr`：

```bash
uname -s | tr '[:upper:]' '[:lower:]'
uname -o | tr '[:upper:]' '[:lower:]'
```

`tr` 已经在同一脚本的 `get_arch()` 中使用，因此这个修改不会引入新的依赖。