### PR TITLE
增加 APT 换源前的 https 支持检测

### DIFF
--- a/src/chsrc-main.c
+++ b/src/chsrc-main.c
@@ -72,6 +72,7 @@ chsrc_register_contributors ()
   chef_register_contributor ("@Mikachu2333",    "Mikachu2333",    "mikachu.23333@zohomail.com",     NULL);
   chef_register_contributor ("@techoc",         "Rui Yang",       "techoc@foxmail.com",             NULL);
   chef_register_contributor ("@BingChunMoLi",   "BingChunMoLi",   "bingchunmoli@bingchunmoli.com",  NULL);
+  chef_register_contributor ("@wcbing",         "wcbing",         "i@wcbing.top",                   NULL);
   // 该注释下一行的用户 ID 为 Gitee ID
   chef_register_contributor ("@hezonglun",      "HeZongLun",      "hezonglun123456@outlook.com",    NULL);
   chef_register_contributor ("@Young-Lord",     "LY",             "ly-niko@qq.com",                 NULL);

--- a/src/recipe/os/APT/Debian.c
+++ b/src/recipe/os/APT/Debian.c
@@ -10,12 +10,12 @@ os_debian_prelude ()
   chef_prep_this (os_debian, gsr);
 
   chef_set_recipe_created_on   (this, "2023-09-02");
-  chef_set_recipe_last_updated (this, "2025-11-09");
+  chef_set_recipe_last_updated (this, "2026-06-26");
   chef_set_sources_last_updated (this, "2025-07-11");
 
   chef_set_chef (this, NULL);
   chef_set_cooks (this, 2, "@ccmywish", "@G_I_Y");
-  chef_set_sauciers (this, 1, "@Yangmoooo");
+  chef_set_sauciers (this, 2, "@Yangmoooo", "@wcbing");
 
   chef_set_os_scope (this);
 
@@ -86,6 +86,8 @@ os_debian_setsrc_for_deb822 (char *option)
 {
   chsrc_use_this_source (os_debian);
 
+  check_https_support (&source);
+
   chsrc_backup (OS_Debian_SourceList_DEB822);
 
   char *cmd = xy_strcat (3, "sed -E -i 's@https?://.*/debian/?@", source.url, "@g' " OS_Debian_SourceList_DEB822);
@@ -102,12 +104,6 @@ os_debian_setsrc_for_deb822 (char *option)
 }
 
 
-/**
- * 处理旧版(非DEB822) sourcelist 的换源
- *
- * Debian 10 Buster 以上版本默认支持 HTTPS 源。如果遇到无法拉取 HTTPS 源的情况，请先使用 HTTP 源并安装
- * apt install apt-transport-https ca-certificates
- */
 void
 os_debian_setsrc (char *option)
 {
@@ -147,8 +143,7 @@ os_debian_setsrc (char *option)
 
   chsrc_use_this_source (os_debian);
 
-  chsrc_alert2 ("如果遇到无法拉取 HTTPS 源的情况，请手动运行:");
-  say ("apt install apt-transport-https ca-certificates");
+  check_https_support (&source);
 
   /* 不存在的时候，用的是我们生成的用来填充占位的无效文件，不要备份 */
   if (sourcelist_exist)

--- a/src/recipe/os/APT/Ubuntu.c
+++ b/src/recipe/os/APT/Ubuntu.c
@@ -11,12 +11,12 @@ os_ubuntu_prelude ()
   chef_prep_this (os_ubuntu, gsr);
 
   chef_set_recipe_created_on   (this, "2023-08-30");
-  chef_set_recipe_last_updated (this, "2026-01-21");
+  chef_set_recipe_last_updated (this, "2026-06-26");
   chef_set_sources_last_updated (this, "2026-01-21");
 
   chef_set_chef (this, NULL);
   chef_set_cooks (this, 2, "@ccmywish", "@G_I_Y");
-  chef_set_sauciers (this, 2, "@XUANJI233", "@usernameisnull");
+  chef_set_sauciers (this, 3, "@XUANJI233", "@usernameisnull", "@wcbing");
 
   chef_set_os_scope (this);
 
@@ -85,6 +85,8 @@ os_ubuntu_setsrc_for_deb822 (char *option)
 {
   chsrc_use_this_source (os_ubuntu);
 
+  check_https_support (&source);
+
   chsrc_backup (OS_Ubuntu_SourceList_DEB822);
 
   char *arch = chsrc_get_cpuarch ();
@@ -127,6 +129,8 @@ os_ubuntu_setsrc (char *option)
   bool sourcelist_exist = ensure_debian_or_ubuntu_old_sourcelist (OS_Is_Ubuntu);
 
   chsrc_use_this_source (os_ubuntu);
+
+  check_https_support (&source);
 
   /* 不存在的时候，用的是我们生成的无效文件，不要备份 */
   if (sourcelist_exist)

--- a/src/recipe/os/APT/common.h
+++ b/src/recipe/os/APT/common.h
@@ -2,11 +2,11 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  * -------------------------------------------------------------
  * File Authors   : @ccmywish
- * Contributors   : @happy-game
+ * Contributors   : @happy-game @wcbing
  *                |
  * Created On     : <2024-06-14>
- * Major Revision :      3
- * Last Modified  : <2025-07-14>
+ * Major Revision :      4
+ * Last Modified  : <2026-06-26>
  * ------------------------------------------------------------*/
 
 #include "rawstr4c.h"
@@ -118,3 +118,26 @@ ensure_debian_or_ubuntu_old_sourcelist (int debian_type)
   fclose (f);
   return false;
 }
+
+
+/**
+ * 检测是否支持 HTTPS 源，若 ca-certificates 安装则支持，否则将 HTTPS 源临时换为 HTTP 源
+ *
+ * @note Debian 10 Buster 以上版本的 APT 默认支持 HTTPS 源，无需安装 apt-transport-https 包。
+ *       如果遇到无法拉取 HTTPS 源的情况，请先使用 HTTP 源并执行 apt install ca-certificates
+ */
+void
+check_https_support (Source_t *source)
+{
+  bool has_ca = xy_file_exist ("/usr/share/doc/ca-certificates/copyright") || xy_file_exist ("/usr/sbin/update-ca-certificates");
+  if (!has_ca && strncmp (source->url, "https://", 8) == 0)
+    {
+      chsrc_warn2 (ENGLISH ? "ca-certificates is not installed, temporarily using http source instead"
+                           : "未检测到 ca-certificates，将临时换为 http 源");
+      source->url = xy_strcat (2, "http://", source->url + 8);
+
+      chsrc_warn2 (ENGLISH ? "Suggest running `apt install ca-certificates` later and change source again to support HTTPS sources"
+                           : "建议稍后执行 `apt install ca-certificates` 并重新换源以支持 HTTPS 源");
+    }
+}
+


### PR DESCRIPTION
## 问题描述

修复 #363 

创建 Debian/Ubuntu 容器（或某些最小化安装的服务器系统，它们未安装 ca-certificates 所以无法正常访问 https），直接使用 `chsrc set <debian/ubuntu> mirrorz` 换系统源。

chsrc 默认是更换 https 源，且脚本并没有判断，只要执行就会换源。一旦换 https 源后 apt 会因为 update 失败而在后续操作中报错。

<br>


## 方案与实现

换源前先判断是否安装了 ca-certificates，如果没安装就直接更换 http 源（同时提醒如何换 https 源）。

判断是否安装 ca-certificates，常规办法是通过 dpkg/apt，但还要截取字符串稍显麻烦。结合现有代码，判断 `/usr/share/doc/ca-certificates/copyright` 等文件是否存在可能更方便。

deepin、Kali Linux 等衍生版一般功能较完整，预装 ca-certificates，所以暂时不增加判断逻辑。

